### PR TITLE
メトリクス名の整理

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,20 @@
 
 ## develop
 
+- [CHANGE] Sora に関するメトリクスの接頭辞を `sora_exporter` から `sora` に変更する
+    - @tnamao
+- [CHANGE] 接続数のメトリクス名を `sora_connections_total` に変更し、状態はラベルに変更する
+    - @tnamao
+- [CHANGE] セッション数のメトリクス名を `sora_session_total` に変更し、状態はラベルに変更する
+    - @tnamao
+- [CHANGE] 接続エラーのメトリクス名を `sora_connection_error_total` に変更し、エラー理由はラベルに変更する
+    - @tnamao
+- [CHANGE] 接続クライアントのメトリクス名を `sora_client_type_total` に変更し、クライアント種別と接続結果はラベルに変更する
+    - @tnamao
+- [CHANGE] `total_received_invalid_turn_tcp_packet` を `received_invalid_turn_tcp_packet_total` に変更する
+    - @tnamao
+- [ADD] Sora への接続可否を判定するための `sora_up` メトリクスを追加する
+    - @tnamao
 - [CHANGE] GitHub リリースのタイトルにタグ名を設定する
     - @tnamao
 - [CHANGE] リリース時のアーカイブファイルに対象の OS 名を含める

--- a/collector/client.go
+++ b/collector/client.go
@@ -5,7 +5,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // この統計情報はアンドキュメントです
 var (
 	clientMetrics = ClientMetrics{
-		totalSoraClientConnections: newDescWithLabel("sora_client_connections_total", "The total number of connections by Sora client types", []string{"type", "state"}),
+		totalSoraClientConnections: newDescWithLabel("client_type_total", "The total number of connections by Sora client types", []string{"client", "state"}),
 	}
 )
 

--- a/collector/client.go
+++ b/collector/client.go
@@ -5,62 +5,29 @@ import "github.com/prometheus/client_golang/prometheus"
 // この統計情報はアンドキュメントです
 var (
 	clientMetrics = ClientMetrics{
-		totalFailedSoraClientTypeSoraAndroidSdk:             newDesc("client_type_sora_android_sdk_failed_total", "The total number of failed connections for Sora Android SDK."),
-		totalFailedSoraClientTypeSoraIosSdk:                 newDesc("client_type_sora_ios_sdk_failed_total", "The total number of failed connections for Sora IOS SDK."),
-		totalFailedSoraClientTypeSoraJsSdk:                  newDesc("client_type_sora_js_sdk_failed_total", "The total number of failed connections for Sora JavaScript SDK."),
-		totalFailedSoraClientTypeSoraUnitySdk:               newDesc("client_type_sora_unity_sdk_failed_total", "The total number of failed connections for Sora Unity SDK."),
-		totalFailedSoraClientTypeUnknown:                    newDesc("client_type_unknown_failed_total", "The total number of failed connections for WebRTC native client Momo."),
-		totalFailedSoraClientTypeWebrtcNativeClientMomo:     newDesc("client_type_webrtc_native_client_monmo_failed_total", "The total number of failed connections for WebRTC native client Momo."),
-		totalSuccessfulSoraClientTypeSoraAndroidSdk:         newDesc("client_type_sora_android_sdk_successful_total", "The total number of successful connections for Sora Android SDK."),
-		totalSuccessfulSoraClientTypeSoraIosSdk:             newDesc("client_type_sora_ios_sdk_successful_total", "The total number of successful connections for Sora IOS SDK."),
-		totalSuccessfulSoraClientTypeSoraJsSdk:              newDesc("client_type_sora_js_sdk_successful_total", "The total number of successful connections for Sora JavaScript SDK."),
-		totalSuccessfulSoraClientTypeSoraUnitySdk:           newDesc("client_type_sora_unity_sdk_successful_total", "The total number of successful connections for Sora Unity SDK."),
-		totalSuccessfulSoraClientTypeUnknown:                newDesc("client_type_known_successful_total", "The total number of successful connections for unknown client"),
-		totalSuccessfulSoraClientTypeWebrtcNativeClientMomo: newDesc("client_type_webrtc_native_client_momo_successful_total", "The total number of successful connections for WebRTC native client Momo."),
+		totalSoraClientConnections: newDescWithLabel("sora_client_connections_total", "The total number of connections by Sora client types", []string{"type", "state"}),
 	}
 )
 
 type ClientMetrics struct {
-	totalFailedSoraClientTypeSoraAndroidSdk             *prometheus.Desc
-	totalFailedSoraClientTypeSoraIosSdk                 *prometheus.Desc
-	totalFailedSoraClientTypeSoraJsSdk                  *prometheus.Desc
-	totalFailedSoraClientTypeSoraUnitySdk               *prometheus.Desc
-	totalFailedSoraClientTypeUnknown                    *prometheus.Desc
-	totalFailedSoraClientTypeWebrtcNativeClientMomo     *prometheus.Desc
-	totalSuccessfulSoraClientTypeSoraAndroidSdk         *prometheus.Desc
-	totalSuccessfulSoraClientTypeSoraIosSdk             *prometheus.Desc
-	totalSuccessfulSoraClientTypeSoraJsSdk              *prometheus.Desc
-	totalSuccessfulSoraClientTypeSoraUnitySdk           *prometheus.Desc
-	totalSuccessfulSoraClientTypeUnknown                *prometheus.Desc
-	totalSuccessfulSoraClientTypeWebrtcNativeClientMomo *prometheus.Desc
+	totalSoraClientConnections *prometheus.Desc
 }
 
 func (m *ClientMetrics) Describe(ch chan<- *prometheus.Desc) {
-	ch <- m.totalFailedSoraClientTypeSoraAndroidSdk
-	ch <- m.totalFailedSoraClientTypeSoraIosSdk
-	ch <- m.totalFailedSoraClientTypeSoraJsSdk
-	ch <- m.totalFailedSoraClientTypeSoraUnitySdk
-	ch <- m.totalFailedSoraClientTypeUnknown
-	ch <- m.totalFailedSoraClientTypeWebrtcNativeClientMomo
-	ch <- m.totalSuccessfulSoraClientTypeSoraAndroidSdk
-	ch <- m.totalSuccessfulSoraClientTypeSoraIosSdk
-	ch <- m.totalSuccessfulSoraClientTypeSoraJsSdk
-	ch <- m.totalSuccessfulSoraClientTypeSoraUnitySdk
-	ch <- m.totalSuccessfulSoraClientTypeUnknown
-	ch <- m.totalSuccessfulSoraClientTypeWebrtcNativeClientMomo
+	ch <- m.totalSoraClientConnections
 }
 
 func (m *ClientMetrics) Collect(ch chan<- prometheus.Metric, report soraClientReport) {
-	ch <- newCounter(m.totalFailedSoraClientTypeSoraAndroidSdk, float64(report.TotalFailedSoraClientType.SoraAndroidSdk))
-	ch <- newCounter(m.totalFailedSoraClientTypeSoraIosSdk, float64(report.TotalFailedSoraClientType.SoraIosSdk))
-	ch <- newCounter(m.totalFailedSoraClientTypeSoraJsSdk, float64(report.TotalFailedSoraClientType.SoraJsSdk))
-	ch <- newCounter(m.totalFailedSoraClientTypeSoraUnitySdk, float64(report.TotalFailedSoraClientType.SoraUnitySdk))
-	ch <- newCounter(m.totalFailedSoraClientTypeUnknown, float64(report.TotalFailedSoraClientType.Unknown))
-	ch <- newCounter(m.totalFailedSoraClientTypeWebrtcNativeClientMomo, float64(report.TotalFailedSoraClientType.WebrtcNativeClientMomo))
-	ch <- newCounter(m.totalSuccessfulSoraClientTypeSoraAndroidSdk, float64(report.TotalSuccessfulSoraClientType.SoraAndroidSdk))
-	ch <- newCounter(m.totalSuccessfulSoraClientTypeSoraIosSdk, float64(report.TotalSuccessfulSoraClientType.SoraIosSdk))
-	ch <- newCounter(m.totalSuccessfulSoraClientTypeSoraJsSdk, float64(report.TotalSuccessfulSoraClientType.SoraJsSdk))
-	ch <- newCounter(m.totalSuccessfulSoraClientTypeSoraUnitySdk, float64(report.TotalSuccessfulSoraClientType.SoraUnitySdk))
-	ch <- newCounter(m.totalSuccessfulSoraClientTypeUnknown, float64(report.TotalSuccessfulSoraClientType.Unknown))
-	ch <- newCounter(m.totalSuccessfulSoraClientTypeWebrtcNativeClientMomo, float64(report.TotalSuccessfulSoraClientType.WebrtcNativeClientMomo))
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraAndroidSdk), "android_sdk", "failed")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraIosSdk), "ios_sdk", "failed")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraJsSdk), "js_sdk", "failed")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraUnitySdk), "unity_sdk", "failed")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.Unknown), "unknown", "failed")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.WebrtcNativeClientMomo), "momo", "failed")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraAndroidSdk), "android_sdk", "successful")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraIosSdk), "ios_sdk", "successful")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraJsSdk), "js_sdk", "successful")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraUnitySdk), "unity_sdk", "successful")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.Unknown), "unknown", "successful")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.WebrtcNativeClientMomo), "momo", "successful")
 }

--- a/collector/client.go
+++ b/collector/client.go
@@ -5,18 +5,18 @@ import "github.com/prometheus/client_golang/prometheus"
 // この統計情報はアンドキュメントです
 var (
 	clientMetrics = ClientMetrics{
-		totalFailedSoraClientTypeSoraAndroidSdk:             newDesc("sora_client_type_sora_android_sdk_failed_total", "The total number of failed connections for Sora Android SDK."),
-		totalFailedSoraClientTypeSoraIosSdk:                 newDesc("sora_client_type_sora_ios_sdk_failed_total", "The total number of failed connections for Sora IOS SDK."),
-		totalFailedSoraClientTypeSoraJsSdk:                  newDesc("sora_client_type_sora_js_sdk_failed_total", "The total number of failed connections for Sora JavaScript SDK."),
-		totalFailedSoraClientTypeSoraUnitySdk:               newDesc("sora_client_type_sora_unity_sdk_failed_total", "The total number of failed connections for Sora Unity SDK."),
-		totalFailedSoraClientTypeUnknown:                    newDesc("sora_client_type_unknown_failed_total", "The total number of failed connections for WebRTC native client Momo."),
-		totalFailedSoraClientTypeWebrtcNativeClientMomo:     newDesc("sora_client_type_webrtc_native_client_monmo_failed_total", "The total number of failed connections for WebRTC native client Momo."),
-		totalSuccessfulSoraClientTypeSoraAndroidSdk:         newDesc("sora_client_type_sora_android_sdk_successful_total", "The total number of successful connections for Sora Android SDK."),
-		totalSuccessfulSoraClientTypeSoraIosSdk:             newDesc("sora_client_type_sora_ios_sdk_successful_total", "The total number of successful connections for Sora IOS SDK."),
-		totalSuccessfulSoraClientTypeSoraJsSdk:              newDesc("sora_client_type_sora_js_sdk_successful_total", "The total number of successful connections for Sora JavaScript SDK."),
-		totalSuccessfulSoraClientTypeSoraUnitySdk:           newDesc("sora_client_type_sora_unity_sdk_successful_total", "The total number of successful connections for Sora Unity SDK."),
-		totalSuccessfulSoraClientTypeUnknown:                newDesc("sora_client_type_known_successful_total", "The total number of successful connections for unknown client"),
-		totalSuccessfulSoraClientTypeWebrtcNativeClientMomo: newDesc("sora_client_type_webrtc_native_client_momo_successful_total", "The total number of successful connections for WebRTC native client Momo."),
+		totalFailedSoraClientTypeSoraAndroidSdk:             newDesc("client_type_sora_android_sdk_failed_total", "The total number of failed connections for Sora Android SDK."),
+		totalFailedSoraClientTypeSoraIosSdk:                 newDesc("client_type_sora_ios_sdk_failed_total", "The total number of failed connections for Sora IOS SDK."),
+		totalFailedSoraClientTypeSoraJsSdk:                  newDesc("client_type_sora_js_sdk_failed_total", "The total number of failed connections for Sora JavaScript SDK."),
+		totalFailedSoraClientTypeSoraUnitySdk:               newDesc("client_type_sora_unity_sdk_failed_total", "The total number of failed connections for Sora Unity SDK."),
+		totalFailedSoraClientTypeUnknown:                    newDesc("client_type_unknown_failed_total", "The total number of failed connections for WebRTC native client Momo."),
+		totalFailedSoraClientTypeWebrtcNativeClientMomo:     newDesc("client_type_webrtc_native_client_monmo_failed_total", "The total number of failed connections for WebRTC native client Momo."),
+		totalSuccessfulSoraClientTypeSoraAndroidSdk:         newDesc("client_type_sora_android_sdk_successful_total", "The total number of successful connections for Sora Android SDK."),
+		totalSuccessfulSoraClientTypeSoraIosSdk:             newDesc("client_type_sora_ios_sdk_successful_total", "The total number of successful connections for Sora IOS SDK."),
+		totalSuccessfulSoraClientTypeSoraJsSdk:              newDesc("client_type_sora_js_sdk_successful_total", "The total number of successful connections for Sora JavaScript SDK."),
+		totalSuccessfulSoraClientTypeSoraUnitySdk:           newDesc("client_type_sora_unity_sdk_successful_total", "The total number of successful connections for Sora Unity SDK."),
+		totalSuccessfulSoraClientTypeUnknown:                newDesc("client_type_known_successful_total", "The total number of successful connections for unknown client"),
+		totalSuccessfulSoraClientTypeWebrtcNativeClientMomo: newDesc("client_type_webrtc_native_client_momo_successful_total", "The total number of successful connections for WebRTC native client Momo."),
 	}
 )
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -57,7 +57,7 @@ func NewCollector(options *CollectorOptions) *Collector {
 		enableErlangVmMetrics:            options.EnableErlangVmMetrics,
 
 		soraUp:                     newDesc("up", "Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no)."),
-		soraVersionInfo:            newDescWithLabel("sora_version_info", "sora version info.", []string{"version"}),
+		soraVersionInfo:            newDescWithLabel("version_info", "sora version info.", []string{"version"}),
 		ConnectionMetrics:          connectionMetrics,
 		ClientMetrics:              clientMetrics,
 		SoraConnectionErrorMetrics: soraConnectionErrorMetrics,

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -126,11 +126,11 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func newDesc(name, help string) *prometheus.Desc {
-	return prometheus.NewDesc(prometheus.BuildFQName("sora", "exporter", name), help, nil, nil)
+	return prometheus.NewDesc(prometheus.BuildFQName("sora", "", name), help, nil, nil)
 }
 
 func newDescWithLabel(name, help string, labels []string) *prometheus.Desc {
-	return prometheus.NewDesc(prometheus.BuildFQName("sora", "exporter", name), help, labels, nil)
+	return prometheus.NewDesc(prometheus.BuildFQName("sora", "", name), help, labels, nil)
 }
 
 func newGauge(d *prometheus.Desc, v float64) prometheus.Metric {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -102,7 +102,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	ch <- newGauge(c.soraUp, 1)
-	ch <- newInfo(c.soraVersionInfo, report.SoraVersion)
+	ch <- newGauge(c.soraVersionInfo, 1, report.SoraVersion)
 	c.ConnectionMetrics.Collect(ch, report.soraConnectionReport)
 
 	if c.enableSoraClientMetrics {
@@ -140,14 +140,10 @@ func newDescWithLabel(name, help string, labels []string) *prometheus.Desc {
 	return prometheus.NewDesc(prometheus.BuildFQName("sora", "", name), help, labels, nil)
 }
 
-func newGauge(d *prometheus.Desc, v float64) prometheus.Metric {
-	return prometheus.MustNewConstMetric(d, prometheus.GaugeValue, v)
+func newGauge(d *prometheus.Desc, v float64, labelValues ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(d, prometheus.GaugeValue, v, labelValues...)
 }
 
-func newCounter(d *prometheus.Desc, v float64) prometheus.Metric {
-	return prometheus.MustNewConstMetric(d, prometheus.CounterValue, v)
-}
-
-func newInfo(d *prometheus.Desc, labelValues ...string) prometheus.Metric {
-	return prometheus.MustNewConstMetric(d, prometheus.GaugeValue, 1, labelValues...)
+func newCounter(d *prometheus.Desc, v float64, labelValues ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(d, prometheus.CounterValue, v, labelValues...)
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -23,6 +23,7 @@ type Collector struct {
 	enableSoraConnectionErrorMetrics bool
 	enableErlangVmMetrics            bool
 
+	soraUp          *prometheus.Desc
 	soraVersionInfo *prometheus.Desc
 	ConnectionMetrics
 	ClientMetrics
@@ -55,6 +56,7 @@ func NewCollector(options *CollectorOptions) *Collector {
 		enableSoraConnectionErrorMetrics: options.EnableSoraConnectionErrorMetrics,
 		enableErlangVmMetrics:            options.EnableErlangVmMetrics,
 
+		soraUp:                     newDesc("up", "Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no)."),
 		soraVersionInfo:            newDescWithLabel("sora_version_info", "sora version info.", []string{"version"}),
 		ConnectionMetrics:          connectionMetrics,
 		ClientMetrics:              clientMetrics,
@@ -73,6 +75,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URI, nil)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to create request to sora", "err", err)
+		ch <- newGauge(c.soraUp, 0)
 		return
 	}
 	req.Header.Set("x-sora-target", "Sora_20171010.GetStatsReport")
@@ -86,6 +89,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	resp, err := client.Do(req)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to request to sora", "err", err)
+		ch <- newGauge(c.soraUp, 0)
 		return
 	}
 	defer resp.Body.Close()
@@ -93,9 +97,11 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	var report soraGetStatsReport
 	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
 		level.Error(c.logger).Log("msg", "failed to decode response body from sora", "err", err)
+		ch <- newGauge(c.soraUp, 0)
 		return
 	}
 
+	ch <- newGauge(c.soraUp, 1)
 	ch <- newInfo(c.soraVersionInfo, report.SoraVersion)
 	c.ConnectionMetrics.Collect(ch, report.soraConnectionReport)
 
@@ -111,6 +117,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.soraUp
 	ch <- c.soraVersionInfo
 	c.ConnectionMetrics.Describe(ch)
 

--- a/collector/connection.go
+++ b/collector/connection.go
@@ -4,70 +4,52 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	connectionMetrics = ConnectionMetrics{
-		totalConnectionCreated:            newDesc("connections_created_total", "The total number of connections created."),
-		totalConnectionUpdated:            newDesc("connections_updated_total", "The total number of connections updated."),
-		totalConnectionDestroyed:          newDesc("connections_destroyed_total", "The total number of connections destryed."),
-		totalSuccessfulConnections:        newDesc("successfull_connections_total", "The total number of successfull connections."),
+		totalConnection:                   newDescWithLabel("connections_total", "The total number of connections created.", []string{"state"}),
 		totalOngoingConnections:           newDesc("ongoing_connections_total", "The total number of ongoing connections."),
-		totalFailedConnections:            newDesc("failed_connections_total", "The total number of failed connections."),
 		totalDurationSec:                  newDesc("duration_seconds_total", "The total duration of connections."),
-		totalTurnUdpConnections:           newDesc("turn_udp_connections_total", "The total number of connections with TURN-UDP."),
-		totalTurnTcpConnections:           newDesc("turn_tcp_connections_total", "The total number of connections with TURN-TCP."),
+		totalTurnConnections:              newDescWithLabel("turn_connections_total", "The total number of connections with TURN.", []string{"proto"}),
 		averageDurationSec:                newDesc("average_duration_seconds", "The average connection duration in seconds."),
 		averageSetupTimeSec:               newDesc("average_setup_time_seconds", "The average setup time in seconds."),
-		totalSessionCreated:               newDesc("total_session_created", "The total number of session created."),
-		totalSessionDestroyed:             newDesc("total_session_destroyed", "The total number of session destroyed."),
-		totalReceivedInvalidTurnTcpPacket: newDesc("total_received_invalid_turn_tcp_packet", "The total number of invalid packets with TURN-TCP"),
+		totalSession:                      newDescWithLabel("session_total", "The total number of session.", []string{"state"}),
+		totalReceivedInvalidTurnTcpPacket: newDesc("received_invalid_turn_tcp_packet_total", "The total number of invalid packets with TURN-TCP"),
 	}
 )
 
 type ConnectionMetrics struct {
-	totalConnectionCreated            *prometheus.Desc
-	totalConnectionUpdated            *prometheus.Desc
-	totalConnectionDestroyed          *prometheus.Desc
-	totalSuccessfulConnections        *prometheus.Desc
+	totalConnection                   *prometheus.Desc
 	totalOngoingConnections           *prometheus.Desc
-	totalFailedConnections            *prometheus.Desc
 	totalDurationSec                  *prometheus.Desc
-	totalTurnUdpConnections           *prometheus.Desc
-	totalTurnTcpConnections           *prometheus.Desc
+	totalTurnConnections              *prometheus.Desc
 	averageDurationSec                *prometheus.Desc
 	averageSetupTimeSec               *prometheus.Desc
-	totalSessionCreated               *prometheus.Desc
-	totalSessionDestroyed             *prometheus.Desc
+	totalSession                      *prometheus.Desc
 	totalReceivedInvalidTurnTcpPacket *prometheus.Desc
 }
 
 func (m *ConnectionMetrics) Describe(ch chan<- *prometheus.Desc) {
-	ch <- m.totalConnectionCreated
-	ch <- m.totalConnectionUpdated
-	ch <- m.totalConnectionDestroyed
-	ch <- m.totalSuccessfulConnections
+	ch <- m.totalConnection
 	ch <- m.totalOngoingConnections
-	ch <- m.totalFailedConnections
 	ch <- m.totalDurationSec
-	ch <- m.totalTurnUdpConnections
-	ch <- m.totalTurnTcpConnections
+	ch <- m.totalTurnConnections
 	ch <- m.averageDurationSec
 	ch <- m.averageSetupTimeSec
-	ch <- m.totalSessionCreated
-	ch <- m.totalSessionDestroyed
+	ch <- m.totalSession
 	ch <- m.totalReceivedInvalidTurnTcpPacket
 }
 
 func (m *ConnectionMetrics) Collect(ch chan<- prometheus.Metric, report soraConnectionReport) {
-	ch <- newCounter(m.totalConnectionCreated, float64(report.TotalConnectionCreated))
-	ch <- newCounter(m.totalConnectionUpdated, float64(report.TotalConnectionUpdated))
-	ch <- newCounter(m.totalConnectionDestroyed, float64(report.TotalConnectionDestroyed))
-	ch <- newCounter(m.totalSuccessfulConnections, float64(report.TotalSuccessfulConnections))
+	ch <- newCounter(m.totalConnection, float64(report.TotalConnectionCreated), "created")
+	ch <- newCounter(m.totalConnection, float64(report.TotalConnectionUpdated), "updated")
+	ch <- newCounter(m.totalConnection, float64(report.TotalConnectionDestroyed), "destroyed")
+	ch <- newCounter(m.totalConnection, float64(report.TotalSuccessfulConnections), "successful")
+	ch <- newCounter(m.totalConnection, float64(report.TotalFailedConnections), "failed")
 	ch <- newGauge(m.totalOngoingConnections, float64(report.TotalOngoingConnections))
-	ch <- newCounter(m.totalFailedConnections, float64(report.TotalFailedConnections))
 	ch <- newCounter(m.totalDurationSec, float64(report.TotalDurationSec))
-	ch <- newCounter(m.totalTurnUdpConnections, float64(report.TotalTurnUdpConnections))
-	ch <- newCounter(m.totalTurnTcpConnections, float64(report.TotalTurnTcpConnections))
+	ch <- newCounter(m.totalTurnConnections, float64(report.TotalTurnUdpConnections), "udp")
+	ch <- newCounter(m.totalTurnConnections, float64(report.TotalTurnTcpConnections), "tcp")
 	ch <- newGauge(m.averageDurationSec, float64(report.AverageDurationSec))
 	ch <- newGauge(m.averageSetupTimeSec, float64(report.AverageSetupTimeMsec/1000))
-	ch <- newCounter(m.totalSessionCreated, float64(report.TotalSessionCreated))
-	ch <- newCounter(m.totalSessionDestroyed, float64(report.TotalSessionDestroyed))
+	ch <- newCounter(m.totalSession, float64(report.TotalSessionCreated), "created")
+	ch <- newCounter(m.totalSession, float64(report.TotalSessionDestroyed), "destroyed")
 	ch <- newCounter(m.totalReceivedInvalidTurnTcpPacket, float64(report.TotalReceivedInvalidTurnTcpPacket))
 }

--- a/collector/connection_error.go
+++ b/collector/connection_error.go
@@ -5,22 +5,19 @@ import "github.com/prometheus/client_golang/prometheus"
 // この統計情報はアンドキュメントです
 var (
 	soraConnectionErrorMetrics = SoraConnectionErrorMetrics{
-		sdpGenerationError: newDesc("sdp_generation_error_total", "The total number of SDP genration error."),
-		signalingError:     newDesc("signaling_error_total", "The total number of signaling error."),
+		connectionError: newDescWithLabel("connection_error_total", "The total number of connection error.", []string{"reason"}),
 	}
 )
 
 type SoraConnectionErrorMetrics struct {
-	sdpGenerationError *prometheus.Desc
-	signalingError     *prometheus.Desc
+	connectionError *prometheus.Desc
 }
 
 func (m *SoraConnectionErrorMetrics) Describe(ch chan<- *prometheus.Desc) {
-	ch <- m.sdpGenerationError
-	ch <- m.signalingError
+	ch <- m.connectionError
 }
 
 func (m *SoraConnectionErrorMetrics) Collect(ch chan<- prometheus.Metric, report soraConnectionErrorReport) {
-	ch <- newCounter(m.sdpGenerationError, float64(report.SdpGenerationError))
-	ch <- newCounter(m.signalingError, float64(report.SignalingError))
+	ch <- newCounter(m.connectionError, float64(report.SdpGenerationError), "sdp")
+	ch <- newCounter(m.connectionError, float64(report.SignalingError), "signaling")
 }

--- a/test/invalid_config.metrics
+++ b/test/invalid_config.metrics
@@ -1,0 +1,3 @@
+# HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
+# TYPE sora_up gauge
+sora_up 0

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -4,6 +4,20 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 0
+# HELP sora_client_type_total The total number of connections by Sora client types
+# TYPE sora_client_type_total counter
+sora_client_type_total{client="android_sdk",state="failed"} 1
+sora_client_type_total{client="android_sdk",state="successful"} 11
+sora_client_type_total{client="ios_sdk",state="failed"} 2
+sora_client_type_total{client="ios_sdk",state="successful"} 22
+sora_client_type_total{client="js_sdk",state="failed"} 3
+sora_client_type_total{client="js_sdk",state="successful"} 33
+sora_client_type_total{client="momo",state="failed"} 6
+sora_client_type_total{client="momo",state="successful"} 66
+sora_client_type_total{client="unity_sdk",state="failed"} 4
+sora_client_type_total{client="unity_sdk",state="successful"} 44
+sora_client_type_total{client="unknown",state="failed"} 5
+sora_client_type_total{client="unknown",state="successful"} 55
 # HELP sora_connection_error_total The total number of connection error.
 # TYPE sora_connection_error_total counter
 sora_connection_error_total{reason="sdp"} 3
@@ -109,20 +123,6 @@ sora_received_invalid_turn_tcp_packet_total 0
 # TYPE sora_session_total counter
 sora_session_total{state="created"} 1
 sora_session_total{state="destroyed"} 0
-# HELP sora_sora_client_connections_total The total number of connections by Sora client types
-# TYPE sora_sora_client_connections_total counter
-sora_sora_client_connections_total{state="failed",type="android_sdk"} 1
-sora_sora_client_connections_total{state="failed",type="ios_sdk"} 2
-sora_sora_client_connections_total{state="failed",type="js_sdk"} 3
-sora_sora_client_connections_total{state="failed",type="momo"} 6
-sora_sora_client_connections_total{state="failed",type="unity_sdk"} 4
-sora_sora_client_connections_total{state="failed",type="unknown"} 5
-sora_sora_client_connections_total{state="successful",type="android_sdk"} 11
-sora_sora_client_connections_total{state="successful",type="ios_sdk"} 22
-sora_sora_client_connections_total{state="successful",type="js_sdk"} 33
-sora_sora_client_connections_total{state="successful",type="momo"} 66
-sora_sora_client_connections_total{state="successful",type="unity_sdk"} 44
-sora_sora_client_connections_total{state="successful",type="unknown"} 55
 # HELP sora_turn_connections_total The total number of connections with TURN.
 # TYPE sora_turn_connections_total counter
 sora_turn_connections_total{proto="tcp"} 2

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -166,3 +166,6 @@ sora_turn_tcp_connections_total 2
 # HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
 # TYPE sora_turn_udp_connections_total counter
 sora_turn_udp_connections_total 0
+# HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
+# TYPE sora_up gauge
+sora_up 1

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -1,168 +1,168 @@
-# HELP sora_exporter_average_duration_seconds The average connection duration in seconds.
-# TYPE sora_exporter_average_duration_seconds gauge
-sora_exporter_average_duration_seconds 706
-# HELP sora_exporter_average_setup_time_seconds The average setup time in seconds.
-# TYPE sora_exporter_average_setup_time_seconds gauge
-sora_exporter_average_setup_time_seconds 0
-# HELP sora_exporter_connections_created_total The total number of connections created.
-# TYPE sora_exporter_connections_created_total counter
-sora_exporter_connections_created_total 2
-# HELP sora_exporter_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_exporter_connections_destroyed_total counter
-sora_exporter_connections_destroyed_total 2
-# HELP sora_exporter_connections_updated_total The total number of connections updated.
-# TYPE sora_exporter_connections_updated_total counter
-sora_exporter_connections_updated_total 23
-# HELP sora_exporter_duration_seconds_total The total duration of connections.
-# TYPE sora_exporter_duration_seconds_total counter
-sora_exporter_duration_seconds_total 1412
-# HELP sora_exporter_erlang_vm_context_switches The total number of context switches since the system started.
-# TYPE sora_exporter_erlang_vm_context_switches counter
-sora_exporter_erlang_vm_context_switches 321
-# HELP sora_exporter_erlang_vm_exact_reductions_exact_reductions_since_last_call The number of exact reductions since last call.
-# TYPE sora_exporter_erlang_vm_exact_reductions_exact_reductions_since_last_call gauge
-sora_exporter_erlang_vm_exact_reductions_exact_reductions_since_last_call 213
-# HELP sora_exporter_erlang_vm_exact_reductions_total_exact_reductions The total number of exact reductions.
-# TYPE sora_exporter_erlang_vm_exact_reductions_total_exact_reductions counter
-sora_exporter_erlang_vm_exact_reductions_total_exact_reductions 432
-# HELP sora_exporter_erlang_vm_garbage_collection_number_of_gcs The number of information about garbage collection.
-# TYPE sora_exporter_erlang_vm_garbage_collection_number_of_gcs gauge
-sora_exporter_erlang_vm_garbage_collection_number_of_gcs 912
-# HELP sora_exporter_erlang_vm_garbage_collection_words_reclaimed The number of information about garbage collection word reclaimed.
-# TYPE sora_exporter_erlang_vm_garbage_collection_words_reclaimed gauge
-sora_exporter_erlang_vm_garbage_collection_words_reclaimed 345
-# HELP sora_exporter_erlang_vm_io_input The total number of bytes received through ports.
-# TYPE sora_exporter_erlang_vm_io_input counter
-sora_exporter_erlang_vm_io_input 769
-# HELP sora_exporter_erlang_vm_io_output The total number of bytes output through ports.
-# TYPE sora_exporter_erlang_vm_io_output counter
-sora_exporter_erlang_vm_io_output 331
-# HELP sora_exporter_erlang_vm_memory_atom The total amount of memory currently allocated for atoms. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_atom gauge
-sora_exporter_erlang_vm_memory_atom 3333
-# HELP sora_exporter_erlang_vm_memory_atom_used The total amount of memory currently used for atoms. This memory is part of the memory presented as atom memory.
-# TYPE sora_exporter_erlang_vm_memory_atom_used gauge
-sora_exporter_erlang_vm_memory_atom_used 2222
-# HELP sora_exporter_erlang_vm_memory_binary The total amount of memory currently allocated for binaries. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_binary gauge
-sora_exporter_erlang_vm_memory_binary 1111
-# HELP sora_exporter_erlang_vm_memory_code The total amount of memory currently allocated for Erlang code. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_code gauge
-sora_exporter_erlang_vm_memory_code 777
-# HELP sora_exporter_erlang_vm_memory_ets The total amount of memory currently allocated for ETS tables. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_ets gauge
-sora_exporter_erlang_vm_memory_ets 888
-# HELP sora_exporter_erlang_vm_memory_processes The total amount of memory currently allocated for the Erlang processes.
-# TYPE sora_exporter_erlang_vm_memory_processes gauge
-sora_exporter_erlang_vm_memory_processes 5678
-# HELP sora_exporter_erlang_vm_memory_processes_used The total amount of memory currently used by the Erlang processes. This is part of the memory presented as processes memory.
-# TYPE sora_exporter_erlang_vm_memory_processes_used gauge
-sora_exporter_erlang_vm_memory_processes_used 6666
-# HELP sora_exporter_erlang_vm_memory_system The total amount of memory currently allocated for the emulator that is not directly related to any Erlang process. Memory presented as processes is not included in this memory. instrument(3) can be used to get a more detailed breakdown of what memory is part of this type.
-# TYPE sora_exporter_erlang_vm_memory_system gauge
-sora_exporter_erlang_vm_memory_system 4444
-# HELP sora_exporter_erlang_vm_memory_total The total amount of memory currently allocated. This is the same as the sum of the memory size for processes and system.
-# TYPE sora_exporter_erlang_vm_memory_total gauge
-sora_exporter_erlang_vm_memory_total 1234
-# HELP sora_exporter_erlang_vm_reductions_reductions_since_last_call The number of information about reductions.
-# TYPE sora_exporter_erlang_vm_reductions_reductions_since_last_call gauge
-sora_exporter_erlang_vm_reductions_reductions_since_last_call 443
-# HELP sora_exporter_erlang_vm_reductions_total_reductions The total number of information about reductions.
-# TYPE sora_exporter_erlang_vm_reductions_total_reductions counter
-sora_exporter_erlang_vm_reductions_total_reductions 8080
-# HELP sora_exporter_erlang_vm_run_queue The total length of all normal and dirty CPU run queues.
-# TYPE sora_exporter_erlang_vm_run_queue gauge
-sora_exporter_erlang_vm_run_queue 0
-# HELP sora_exporter_erlang_vm_runtime_time_since_last_call The number of information about runtime since last call, in milliseconds.
-# TYPE sora_exporter_erlang_vm_runtime_time_since_last_call gauge
-sora_exporter_erlang_vm_runtime_time_since_last_call 100
-# HELP sora_exporter_erlang_vm_runtime_total_run_time The number of information about runtime, in milliseconds.
-# TYPE sora_exporter_erlang_vm_runtime_total_run_time gauge
-sora_exporter_erlang_vm_runtime_total_run_time 200
-# HELP sora_exporter_erlang_vm_total_active_tasks The number of active processes and ports on each run queue and its associated schedulers. (only tasks that are expected to be CPU bound are part of the result.)
-# TYPE sora_exporter_erlang_vm_total_active_tasks gauge
-sora_exporter_erlang_vm_total_active_tasks 1
-# HELP sora_exporter_erlang_vm_total_active_tasks_all The number of active processes and ports on each run queue and its associated schedulers.
-# TYPE sora_exporter_erlang_vm_total_active_tasks_all gauge
-sora_exporter_erlang_vm_total_active_tasks_all 1
-# HELP sora_exporter_erlang_vm_total_run_queue_lengths The number of processes and ports ready to run for each run queue. (only run queues with work that is expected to be CPU bound is part of the result.)
-# TYPE sora_exporter_erlang_vm_total_run_queue_lengths gauge
-sora_exporter_erlang_vm_total_run_queue_lengths 0
-# HELP sora_exporter_erlang_vm_total_run_queue_lengths_all The number of processes and ports ready to run for each run queue.
-# TYPE sora_exporter_erlang_vm_total_run_queue_lengths_all gauge
-sora_exporter_erlang_vm_total_run_queue_lengths_all 0
-# HELP sora_exporter_erlang_vm_wall_clock_total_wallclock_time The number of information about wall clock.
-# TYPE sora_exporter_erlang_vm_wall_clock_total_wallclock_time gauge
-sora_exporter_erlang_vm_wall_clock_total_wallclock_time 994
-# HELP sora_exporter_erlang_vm_wall_clock_wallclock_time_since_last_call The number of information about wall clock since last call.
-# TYPE sora_exporter_erlang_vm_wall_clock_wallclock_time_since_last_call gauge
-sora_exporter_erlang_vm_wall_clock_wallclock_time_since_last_call 9090
-# HELP sora_exporter_failed_connections_total The total number of failed connections.
-# TYPE sora_exporter_failed_connections_total counter
-sora_exporter_failed_connections_total 0
-# HELP sora_exporter_ongoing_connections_total The total number of ongoing connections.
-# TYPE sora_exporter_ongoing_connections_total gauge
-sora_exporter_ongoing_connections_total 0
-# HELP sora_exporter_sdp_generation_error_total The total number of SDP genration error.
-# TYPE sora_exporter_sdp_generation_error_total counter
-sora_exporter_sdp_generation_error_total 3
-# HELP sora_exporter_signaling_error_total The total number of signaling error.
-# TYPE sora_exporter_signaling_error_total counter
-sora_exporter_signaling_error_total 4
-# HELP sora_exporter_sora_client_type_known_successful_total The total number of successful connections for unknown client
-# TYPE sora_exporter_sora_client_type_known_successful_total counter
-sora_exporter_sora_client_type_known_successful_total 55
-# HELP sora_exporter_sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
-# TYPE sora_exporter_sora_client_type_sora_android_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_android_sdk_failed_total 1
-# HELP sora_exporter_sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
-# TYPE sora_exporter_sora_client_type_sora_android_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_android_sdk_successful_total 11
-# HELP sora_exporter_sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
-# TYPE sora_exporter_sora_client_type_sora_ios_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_ios_sdk_failed_total 2
-# HELP sora_exporter_sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
-# TYPE sora_exporter_sora_client_type_sora_ios_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_ios_sdk_successful_total 22
-# HELP sora_exporter_sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
-# TYPE sora_exporter_sora_client_type_sora_js_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_js_sdk_failed_total 3
-# HELP sora_exporter_sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
-# TYPE sora_exporter_sora_client_type_sora_js_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_js_sdk_successful_total 33
-# HELP sora_exporter_sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
-# TYPE sora_exporter_sora_client_type_sora_unity_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_unity_sdk_failed_total 4
-# HELP sora_exporter_sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
-# TYPE sora_exporter_sora_client_type_sora_unity_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_unity_sdk_successful_total 44
-# HELP sora_exporter_sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_exporter_sora_client_type_unknown_failed_total counter
-sora_exporter_sora_client_type_unknown_failed_total 5
-# HELP sora_exporter_sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
-# TYPE sora_exporter_sora_client_type_webrtc_native_client_momo_successful_total counter
-sora_exporter_sora_client_type_webrtc_native_client_momo_successful_total 66
-# HELP sora_exporter_sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_exporter_sora_client_type_webrtc_native_client_monmo_failed_total counter
-sora_exporter_sora_client_type_webrtc_native_client_monmo_failed_total 6
-# HELP sora_exporter_sora_version_info sora version info.
-# TYPE sora_exporter_sora_version_info gauge
-sora_exporter_sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_exporter_successfull_connections_total The total number of successfull connections.
-# TYPE sora_exporter_successfull_connections_total counter
-sora_exporter_successfull_connections_total 2
-# HELP sora_exporter_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_exporter_total_received_invalid_turn_tcp_packet counter
-sora_exporter_total_received_invalid_turn_tcp_packet 0
-# HELP sora_exporter_total_session_created The total number of session created.
-# TYPE sora_exporter_total_session_created counter
-sora_exporter_total_session_created 1
-# HELP sora_exporter_total_session_destroyed The total number of session destroyed.
-# TYPE sora_exporter_total_session_destroyed counter
-sora_exporter_total_session_destroyed 0
-# HELP sora_exporter_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_exporter_turn_tcp_connections_total counter
-sora_exporter_turn_tcp_connections_total 2
-# HELP sora_exporter_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_exporter_turn_udp_connections_total counter
-sora_exporter_turn_udp_connections_total 0
+# HELP sora_average_duration_seconds The average connection duration in seconds.
+# TYPE sora_average_duration_seconds gauge
+sora_average_duration_seconds 706
+# HELP sora_average_setup_time_seconds The average setup time in seconds.
+# TYPE sora_average_setup_time_seconds gauge
+sora_average_setup_time_seconds 0
+# HELP sora_connections_created_total The total number of connections created.
+# TYPE sora_connections_created_total counter
+sora_connections_created_total 2
+# HELP sora_connections_destroyed_total The total number of connections destryed.
+# TYPE sora_connections_destroyed_total counter
+sora_connections_destroyed_total 2
+# HELP sora_connections_updated_total The total number of connections updated.
+# TYPE sora_connections_updated_total counter
+sora_connections_updated_total 23
+# HELP sora_duration_seconds_total The total duration of connections.
+# TYPE sora_duration_seconds_total counter
+sora_duration_seconds_total 1412
+# HELP sora_erlang_vm_context_switches The total number of context switches since the system started.
+# TYPE sora_erlang_vm_context_switches counter
+sora_erlang_vm_context_switches 321
+# HELP sora_erlang_vm_exact_reductions_exact_reductions_since_last_call The number of exact reductions since last call.
+# TYPE sora_erlang_vm_exact_reductions_exact_reductions_since_last_call gauge
+sora_erlang_vm_exact_reductions_exact_reductions_since_last_call 213
+# HELP sora_erlang_vm_exact_reductions_total_exact_reductions The total number of exact reductions.
+# TYPE sora_erlang_vm_exact_reductions_total_exact_reductions counter
+sora_erlang_vm_exact_reductions_total_exact_reductions 432
+# HELP sora_erlang_vm_garbage_collection_number_of_gcs The number of information about garbage collection.
+# TYPE sora_erlang_vm_garbage_collection_number_of_gcs gauge
+sora_erlang_vm_garbage_collection_number_of_gcs 912
+# HELP sora_erlang_vm_garbage_collection_words_reclaimed The number of information about garbage collection word reclaimed.
+# TYPE sora_erlang_vm_garbage_collection_words_reclaimed gauge
+sora_erlang_vm_garbage_collection_words_reclaimed 345
+# HELP sora_erlang_vm_io_input The total number of bytes received through ports.
+# TYPE sora_erlang_vm_io_input counter
+sora_erlang_vm_io_input 769
+# HELP sora_erlang_vm_io_output The total number of bytes output through ports.
+# TYPE sora_erlang_vm_io_output counter
+sora_erlang_vm_io_output 331
+# HELP sora_erlang_vm_memory_atom The total amount of memory currently allocated for atoms. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_atom gauge
+sora_erlang_vm_memory_atom 3333
+# HELP sora_erlang_vm_memory_atom_used The total amount of memory currently used for atoms. This memory is part of the memory presented as atom memory.
+# TYPE sora_erlang_vm_memory_atom_used gauge
+sora_erlang_vm_memory_atom_used 2222
+# HELP sora_erlang_vm_memory_binary The total amount of memory currently allocated for binaries. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_binary gauge
+sora_erlang_vm_memory_binary 1111
+# HELP sora_erlang_vm_memory_code The total amount of memory currently allocated for Erlang code. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_code gauge
+sora_erlang_vm_memory_code 777
+# HELP sora_erlang_vm_memory_ets The total amount of memory currently allocated for ETS tables. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_ets gauge
+sora_erlang_vm_memory_ets 888
+# HELP sora_erlang_vm_memory_processes The total amount of memory currently allocated for the Erlang processes.
+# TYPE sora_erlang_vm_memory_processes gauge
+sora_erlang_vm_memory_processes 5678
+# HELP sora_erlang_vm_memory_processes_used The total amount of memory currently used by the Erlang processes. This is part of the memory presented as processes memory.
+# TYPE sora_erlang_vm_memory_processes_used gauge
+sora_erlang_vm_memory_processes_used 6666
+# HELP sora_erlang_vm_memory_system The total amount of memory currently allocated for the emulator that is not directly related to any Erlang process. Memory presented as processes is not included in this memory. instrument(3) can be used to get a more detailed breakdown of what memory is part of this type.
+# TYPE sora_erlang_vm_memory_system gauge
+sora_erlang_vm_memory_system 4444
+# HELP sora_erlang_vm_memory_total The total amount of memory currently allocated. This is the same as the sum of the memory size for processes and system.
+# TYPE sora_erlang_vm_memory_total gauge
+sora_erlang_vm_memory_total 1234
+# HELP sora_erlang_vm_reductions_reductions_since_last_call The number of information about reductions.
+# TYPE sora_erlang_vm_reductions_reductions_since_last_call gauge
+sora_erlang_vm_reductions_reductions_since_last_call 443
+# HELP sora_erlang_vm_reductions_total_reductions The total number of information about reductions.
+# TYPE sora_erlang_vm_reductions_total_reductions counter
+sora_erlang_vm_reductions_total_reductions 8080
+# HELP sora_erlang_vm_run_queue The total length of all normal and dirty CPU run queues.
+# TYPE sora_erlang_vm_run_queue gauge
+sora_erlang_vm_run_queue 0
+# HELP sora_erlang_vm_runtime_time_since_last_call The number of information about runtime since last call, in milliseconds.
+# TYPE sora_erlang_vm_runtime_time_since_last_call gauge
+sora_erlang_vm_runtime_time_since_last_call 100
+# HELP sora_erlang_vm_runtime_total_run_time The number of information about runtime, in milliseconds.
+# TYPE sora_erlang_vm_runtime_total_run_time gauge
+sora_erlang_vm_runtime_total_run_time 200
+# HELP sora_erlang_vm_total_active_tasks The number of active processes and ports on each run queue and its associated schedulers. (only tasks that are expected to be CPU bound are part of the result.)
+# TYPE sora_erlang_vm_total_active_tasks gauge
+sora_erlang_vm_total_active_tasks 1
+# HELP sora_erlang_vm_total_active_tasks_all The number of active processes and ports on each run queue and its associated schedulers.
+# TYPE sora_erlang_vm_total_active_tasks_all gauge
+sora_erlang_vm_total_active_tasks_all 1
+# HELP sora_erlang_vm_total_run_queue_lengths The number of processes and ports ready to run for each run queue. (only run queues with work that is expected to be CPU bound is part of the result.)
+# TYPE sora_erlang_vm_total_run_queue_lengths gauge
+sora_erlang_vm_total_run_queue_lengths 0
+# HELP sora_erlang_vm_total_run_queue_lengths_all The number of processes and ports ready to run for each run queue.
+# TYPE sora_erlang_vm_total_run_queue_lengths_all gauge
+sora_erlang_vm_total_run_queue_lengths_all 0
+# HELP sora_erlang_vm_wall_clock_total_wallclock_time The number of information about wall clock.
+# TYPE sora_erlang_vm_wall_clock_total_wallclock_time gauge
+sora_erlang_vm_wall_clock_total_wallclock_time 994
+# HELP sora_erlang_vm_wall_clock_wallclock_time_since_last_call The number of information about wall clock since last call.
+# TYPE sora_erlang_vm_wall_clock_wallclock_time_since_last_call gauge
+sora_erlang_vm_wall_clock_wallclock_time_since_last_call 9090
+# HELP sora_failed_connections_total The total number of failed connections.
+# TYPE sora_failed_connections_total counter
+sora_failed_connections_total 0
+# HELP sora_ongoing_connections_total The total number of ongoing connections.
+# TYPE sora_ongoing_connections_total gauge
+sora_ongoing_connections_total 0
+# HELP sora_sdp_generation_error_total The total number of SDP genration error.
+# TYPE sora_sdp_generation_error_total counter
+sora_sdp_generation_error_total 3
+# HELP sora_signaling_error_total The total number of signaling error.
+# TYPE sora_signaling_error_total counter
+sora_signaling_error_total 4
+# HELP sora_sora_client_type_known_successful_total The total number of successful connections for unknown client
+# TYPE sora_sora_client_type_known_successful_total counter
+sora_sora_client_type_known_successful_total 55
+# HELP sora_sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
+# TYPE sora_sora_client_type_sora_android_sdk_failed_total counter
+sora_sora_client_type_sora_android_sdk_failed_total 1
+# HELP sora_sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
+# TYPE sora_sora_client_type_sora_android_sdk_successful_total counter
+sora_sora_client_type_sora_android_sdk_successful_total 11
+# HELP sora_sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
+# TYPE sora_sora_client_type_sora_ios_sdk_failed_total counter
+sora_sora_client_type_sora_ios_sdk_failed_total 2
+# HELP sora_sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
+# TYPE sora_sora_client_type_sora_ios_sdk_successful_total counter
+sora_sora_client_type_sora_ios_sdk_successful_total 22
+# HELP sora_sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
+# TYPE sora_sora_client_type_sora_js_sdk_failed_total counter
+sora_sora_client_type_sora_js_sdk_failed_total 3
+# HELP sora_sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
+# TYPE sora_sora_client_type_sora_js_sdk_successful_total counter
+sora_sora_client_type_sora_js_sdk_successful_total 33
+# HELP sora_sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
+# TYPE sora_sora_client_type_sora_unity_sdk_failed_total counter
+sora_sora_client_type_sora_unity_sdk_failed_total 4
+# HELP sora_sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
+# TYPE sora_sora_client_type_sora_unity_sdk_successful_total counter
+sora_sora_client_type_sora_unity_sdk_successful_total 44
+# HELP sora_sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_sora_client_type_unknown_failed_total counter
+sora_sora_client_type_unknown_failed_total 5
+# HELP sora_sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
+# TYPE sora_sora_client_type_webrtc_native_client_momo_successful_total counter
+sora_sora_client_type_webrtc_native_client_momo_successful_total 66
+# HELP sora_sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_sora_client_type_webrtc_native_client_monmo_failed_total counter
+sora_sora_client_type_webrtc_native_client_monmo_failed_total 6
+# HELP sora_sora_version_info sora version info.
+# TYPE sora_sora_version_info gauge
+sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_successfull_connections_total The total number of successfull connections.
+# TYPE sora_successfull_connections_total counter
+sora_successfull_connections_total 2
+# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
+# TYPE sora_total_received_invalid_turn_tcp_packet counter
+sora_total_received_invalid_turn_tcp_packet 0
+# HELP sora_total_session_created The total number of session created.
+# TYPE sora_total_session_created counter
+sora_total_session_created 1
+# HELP sora_total_session_destroyed The total number of session destroyed.
+# TYPE sora_total_session_destroyed counter
+sora_total_session_destroyed 0
+# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
+# TYPE sora_turn_tcp_connections_total counter
+sora_turn_tcp_connections_total 2
+# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
+# TYPE sora_turn_udp_connections_total counter
+sora_turn_udp_connections_total 0

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -4,15 +4,17 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 0
-# HELP sora_connections_created_total The total number of connections created.
-# TYPE sora_connections_created_total counter
-sora_connections_created_total 2
-# HELP sora_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_connections_destroyed_total counter
-sora_connections_destroyed_total 2
-# HELP sora_connections_updated_total The total number of connections updated.
-# TYPE sora_connections_updated_total counter
-sora_connections_updated_total 23
+# HELP sora_connection_error_total The total number of connection error.
+# TYPE sora_connection_error_total counter
+sora_connection_error_total{reason="sdp"} 3
+sora_connection_error_total{reason="signaling"} 4
+# HELP sora_connections_total The total number of connections created.
+# TYPE sora_connections_total counter
+sora_connections_total{state="created"} 2
+sora_connections_total{state="destroyed"} 2
+sora_connections_total{state="failed"} 0
+sora_connections_total{state="successful"} 2
+sora_connections_total{state="updated"} 23
 # HELP sora_duration_seconds_total The total duration of connections.
 # TYPE sora_duration_seconds_total counter
 sora_duration_seconds_total 1412
@@ -97,75 +99,37 @@ sora_erlang_vm_wall_clock_total_wallclock_time 994
 # HELP sora_erlang_vm_wall_clock_wallclock_time_since_last_call The number of information about wall clock since last call.
 # TYPE sora_erlang_vm_wall_clock_wallclock_time_since_last_call gauge
 sora_erlang_vm_wall_clock_wallclock_time_since_last_call 9090
-# HELP sora_failed_connections_total The total number of failed connections.
-# TYPE sora_failed_connections_total counter
-sora_failed_connections_total 0
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 0
-# HELP sora_sdp_generation_error_total The total number of SDP genration error.
-# TYPE sora_sdp_generation_error_total counter
-sora_sdp_generation_error_total 3
-# HELP sora_signaling_error_total The total number of signaling error.
-# TYPE sora_signaling_error_total counter
-sora_signaling_error_total 4
-# HELP sora_client_type_known_successful_total The total number of successful connections for unknown client
-# TYPE sora_client_type_known_successful_total counter
-sora_client_type_known_successful_total 55
-# HELP sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
-# TYPE sora_client_type_sora_android_sdk_failed_total counter
-sora_client_type_sora_android_sdk_failed_total 1
-# HELP sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
-# TYPE sora_client_type_sora_android_sdk_successful_total counter
-sora_client_type_sora_android_sdk_successful_total 11
-# HELP sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
-# TYPE sora_client_type_sora_ios_sdk_failed_total counter
-sora_client_type_sora_ios_sdk_failed_total 2
-# HELP sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
-# TYPE sora_client_type_sora_ios_sdk_successful_total counter
-sora_client_type_sora_ios_sdk_successful_total 22
-# HELP sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
-# TYPE sora_client_type_sora_js_sdk_failed_total counter
-sora_client_type_sora_js_sdk_failed_total 3
-# HELP sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
-# TYPE sora_client_type_sora_js_sdk_successful_total counter
-sora_client_type_sora_js_sdk_successful_total 33
-# HELP sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
-# TYPE sora_client_type_sora_unity_sdk_failed_total counter
-sora_client_type_sora_unity_sdk_failed_total 4
-# HELP sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
-# TYPE sora_client_type_sora_unity_sdk_successful_total counter
-sora_client_type_sora_unity_sdk_successful_total 44
-# HELP sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_client_type_unknown_failed_total counter
-sora_client_type_unknown_failed_total 5
-# HELP sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
-# TYPE sora_client_type_webrtc_native_client_momo_successful_total counter
-sora_client_type_webrtc_native_client_momo_successful_total 66
-# HELP sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_client_type_webrtc_native_client_monmo_failed_total counter
-sora_client_type_webrtc_native_client_monmo_failed_total 6
-# HELP sora_version_info sora version info.
-# TYPE sora_version_info gauge
-sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_successfull_connections_total The total number of successfull connections.
-# TYPE sora_successfull_connections_total counter
-sora_successfull_connections_total 2
-# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_total_received_invalid_turn_tcp_packet counter
-sora_total_received_invalid_turn_tcp_packet 0
-# HELP sora_total_session_created The total number of session created.
-# TYPE sora_total_session_created counter
-sora_total_session_created 1
-# HELP sora_total_session_destroyed The total number of session destroyed.
-# TYPE sora_total_session_destroyed counter
-sora_total_session_destroyed 0
-# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_turn_tcp_connections_total counter
-sora_turn_tcp_connections_total 2
-# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_turn_udp_connections_total counter
-sora_turn_udp_connections_total 0
+# HELP sora_received_invalid_turn_tcp_packet_total The total number of invalid packets with TURN-TCP
+# TYPE sora_received_invalid_turn_tcp_packet_total counter
+sora_received_invalid_turn_tcp_packet_total 0
+# HELP sora_session_total The total number of session.
+# TYPE sora_session_total counter
+sora_session_total{state="created"} 1
+sora_session_total{state="destroyed"} 0
+# HELP sora_sora_client_connections_total The total number of connections by Sora client types
+# TYPE sora_sora_client_connections_total counter
+sora_sora_client_connections_total{state="failed",type="android_sdk"} 1
+sora_sora_client_connections_total{state="failed",type="ios_sdk"} 2
+sora_sora_client_connections_total{state="failed",type="js_sdk"} 3
+sora_sora_client_connections_total{state="failed",type="momo"} 6
+sora_sora_client_connections_total{state="failed",type="unity_sdk"} 4
+sora_sora_client_connections_total{state="failed",type="unknown"} 5
+sora_sora_client_connections_total{state="successful",type="android_sdk"} 11
+sora_sora_client_connections_total{state="successful",type="ios_sdk"} 22
+sora_sora_client_connections_total{state="successful",type="js_sdk"} 33
+sora_sora_client_connections_total{state="successful",type="momo"} 66
+sora_sora_client_connections_total{state="successful",type="unity_sdk"} 44
+sora_sora_client_connections_total{state="successful",type="unknown"} 55
+# HELP sora_turn_connections_total The total number of connections with TURN.
+# TYPE sora_turn_connections_total counter
+sora_turn_connections_total{proto="tcp"} 2
+sora_turn_connections_total{proto="udp"} 0
 # HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
 # TYPE sora_up gauge
 sora_up 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -109,45 +109,45 @@ sora_sdp_generation_error_total 3
 # HELP sora_signaling_error_total The total number of signaling error.
 # TYPE sora_signaling_error_total counter
 sora_signaling_error_total 4
-# HELP sora_sora_client_type_known_successful_total The total number of successful connections for unknown client
-# TYPE sora_sora_client_type_known_successful_total counter
-sora_sora_client_type_known_successful_total 55
-# HELP sora_sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
-# TYPE sora_sora_client_type_sora_android_sdk_failed_total counter
-sora_sora_client_type_sora_android_sdk_failed_total 1
-# HELP sora_sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
-# TYPE sora_sora_client_type_sora_android_sdk_successful_total counter
-sora_sora_client_type_sora_android_sdk_successful_total 11
-# HELP sora_sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
-# TYPE sora_sora_client_type_sora_ios_sdk_failed_total counter
-sora_sora_client_type_sora_ios_sdk_failed_total 2
-# HELP sora_sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
-# TYPE sora_sora_client_type_sora_ios_sdk_successful_total counter
-sora_sora_client_type_sora_ios_sdk_successful_total 22
-# HELP sora_sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
-# TYPE sora_sora_client_type_sora_js_sdk_failed_total counter
-sora_sora_client_type_sora_js_sdk_failed_total 3
-# HELP sora_sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
-# TYPE sora_sora_client_type_sora_js_sdk_successful_total counter
-sora_sora_client_type_sora_js_sdk_successful_total 33
-# HELP sora_sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
-# TYPE sora_sora_client_type_sora_unity_sdk_failed_total counter
-sora_sora_client_type_sora_unity_sdk_failed_total 4
-# HELP sora_sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
-# TYPE sora_sora_client_type_sora_unity_sdk_successful_total counter
-sora_sora_client_type_sora_unity_sdk_successful_total 44
-# HELP sora_sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_sora_client_type_unknown_failed_total counter
-sora_sora_client_type_unknown_failed_total 5
-# HELP sora_sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
-# TYPE sora_sora_client_type_webrtc_native_client_momo_successful_total counter
-sora_sora_client_type_webrtc_native_client_momo_successful_total 66
-# HELP sora_sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_sora_client_type_webrtc_native_client_monmo_failed_total counter
-sora_sora_client_type_webrtc_native_client_monmo_failed_total 6
-# HELP sora_sora_version_info sora version info.
-# TYPE sora_sora_version_info gauge
-sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_client_type_known_successful_total The total number of successful connections for unknown client
+# TYPE sora_client_type_known_successful_total counter
+sora_client_type_known_successful_total 55
+# HELP sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
+# TYPE sora_client_type_sora_android_sdk_failed_total counter
+sora_client_type_sora_android_sdk_failed_total 1
+# HELP sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
+# TYPE sora_client_type_sora_android_sdk_successful_total counter
+sora_client_type_sora_android_sdk_successful_total 11
+# HELP sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
+# TYPE sora_client_type_sora_ios_sdk_failed_total counter
+sora_client_type_sora_ios_sdk_failed_total 2
+# HELP sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
+# TYPE sora_client_type_sora_ios_sdk_successful_total counter
+sora_client_type_sora_ios_sdk_successful_total 22
+# HELP sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
+# TYPE sora_client_type_sora_js_sdk_failed_total counter
+sora_client_type_sora_js_sdk_failed_total 3
+# HELP sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
+# TYPE sora_client_type_sora_js_sdk_successful_total counter
+sora_client_type_sora_js_sdk_successful_total 33
+# HELP sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
+# TYPE sora_client_type_sora_unity_sdk_failed_total counter
+sora_client_type_sora_unity_sdk_failed_total 4
+# HELP sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
+# TYPE sora_client_type_sora_unity_sdk_successful_total counter
+sora_client_type_sora_unity_sdk_successful_total 44
+# HELP sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_client_type_unknown_failed_total counter
+sora_client_type_unknown_failed_total 5
+# HELP sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
+# TYPE sora_client_type_webrtc_native_client_momo_successful_total counter
+sora_client_type_webrtc_native_client_momo_successful_total 66
+# HELP sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_client_type_webrtc_native_client_monmo_failed_total counter
+sora_client_type_webrtc_native_client_monmo_failed_total 6
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1
 # HELP sora_successfull_connections_total The total number of successfull connections.
 # TYPE sora_successfull_connections_total counter
 sora_successfull_connections_total 2

--- a/test/minimum.metrics
+++ b/test/minimum.metrics
@@ -22,9 +22,9 @@ sora_failed_connections_total 100
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 88
-# HELP sora_sora_version_info sora version info.
-# TYPE sora_sora_version_info gauge
-sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1
 # HELP sora_successfull_connections_total The total number of successfull connections.
 # TYPE sora_successfull_connections_total counter
 sora_successfull_connections_total 333

--- a/test/minimum.metrics
+++ b/test/minimum.metrics
@@ -4,45 +4,33 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 12
-# HELP sora_connections_created_total The total number of connections created.
-# TYPE sora_connections_created_total counter
-sora_connections_created_total 3
-# HELP sora_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_connections_destroyed_total counter
-sora_connections_destroyed_total 2
-# HELP sora_connections_updated_total The total number of connections updated.
-# TYPE sora_connections_updated_total counter
-sora_connections_updated_total 23
+# HELP sora_connections_total The total number of connections created.
+# TYPE sora_connections_total counter
+sora_connections_total{state="created"} 3
+sora_connections_total{state="destroyed"} 2
+sora_connections_total{state="failed"} 100
+sora_connections_total{state="successful"} 333
+sora_connections_total{state="updated"} 23
 # HELP sora_duration_seconds_total The total duration of connections.
 # TYPE sora_duration_seconds_total counter
 sora_duration_seconds_total 1412
-# HELP sora_failed_connections_total The total number of failed connections.
-# TYPE sora_failed_connections_total counter
-sora_failed_connections_total 100
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 88
-# HELP sora_version_info sora version info.
-# TYPE sora_version_info gauge
-sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_successfull_connections_total The total number of successfull connections.
-# TYPE sora_successfull_connections_total counter
-sora_successfull_connections_total 333
-# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_total_received_invalid_turn_tcp_packet counter
-sora_total_received_invalid_turn_tcp_packet 123
-# HELP sora_total_session_created The total number of session created.
-# TYPE sora_total_session_created counter
-sora_total_session_created 111
-# HELP sora_total_session_destroyed The total number of session destroyed.
-# TYPE sora_total_session_destroyed counter
-sora_total_session_destroyed 222
-# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_turn_tcp_connections_total counter
-sora_turn_tcp_connections_total 444
-# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_turn_udp_connections_total counter
-sora_turn_udp_connections_total 555
+# HELP sora_received_invalid_turn_tcp_packet_total The total number of invalid packets with TURN-TCP
+# TYPE sora_received_invalid_turn_tcp_packet_total counter
+sora_received_invalid_turn_tcp_packet_total 123
+# HELP sora_session_total The total number of session.
+# TYPE sora_session_total counter
+sora_session_total{state="created"} 111
+sora_session_total{state="destroyed"} 222
+# HELP sora_turn_connections_total The total number of connections with TURN.
+# TYPE sora_turn_connections_total counter
+sora_turn_connections_total{proto="tcp"} 444
+sora_turn_connections_total{proto="udp"} 555
 # HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
 # TYPE sora_up gauge
 sora_up 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1

--- a/test/minimum.metrics
+++ b/test/minimum.metrics
@@ -43,3 +43,6 @@ sora_turn_tcp_connections_total 444
 # HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
 # TYPE sora_turn_udp_connections_total counter
 sora_turn_udp_connections_total 555
+# HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
+# TYPE sora_up gauge
+sora_up 1

--- a/test/minimum.metrics
+++ b/test/minimum.metrics
@@ -1,45 +1,45 @@
-# HELP sora_exporter_average_duration_seconds The average connection duration in seconds.
-# TYPE sora_exporter_average_duration_seconds gauge
-sora_exporter_average_duration_seconds 706
-# HELP sora_exporter_average_setup_time_seconds The average setup time in seconds.
-# TYPE sora_exporter_average_setup_time_seconds gauge
-sora_exporter_average_setup_time_seconds 12
-# HELP sora_exporter_connections_created_total The total number of connections created.
-# TYPE sora_exporter_connections_created_total counter
-sora_exporter_connections_created_total 3
-# HELP sora_exporter_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_exporter_connections_destroyed_total counter
-sora_exporter_connections_destroyed_total 2
-# HELP sora_exporter_connections_updated_total The total number of connections updated.
-# TYPE sora_exporter_connections_updated_total counter
-sora_exporter_connections_updated_total 23
-# HELP sora_exporter_duration_seconds_total The total duration of connections.
-# TYPE sora_exporter_duration_seconds_total counter
-sora_exporter_duration_seconds_total 1412
-# HELP sora_exporter_failed_connections_total The total number of failed connections.
-# TYPE sora_exporter_failed_connections_total counter
-sora_exporter_failed_connections_total 100
-# HELP sora_exporter_ongoing_connections_total The total number of ongoing connections.
-# TYPE sora_exporter_ongoing_connections_total gauge
-sora_exporter_ongoing_connections_total 88
-# HELP sora_exporter_sora_version_info sora version info.
-# TYPE sora_exporter_sora_version_info gauge
-sora_exporter_sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_exporter_successfull_connections_total The total number of successfull connections.
-# TYPE sora_exporter_successfull_connections_total counter
-sora_exporter_successfull_connections_total 333
-# HELP sora_exporter_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_exporter_total_received_invalid_turn_tcp_packet counter
-sora_exporter_total_received_invalid_turn_tcp_packet 123
-# HELP sora_exporter_total_session_created The total number of session created.
-# TYPE sora_exporter_total_session_created counter
-sora_exporter_total_session_created 111
-# HELP sora_exporter_total_session_destroyed The total number of session destroyed.
-# TYPE sora_exporter_total_session_destroyed counter
-sora_exporter_total_session_destroyed 222
-# HELP sora_exporter_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_exporter_turn_tcp_connections_total counter
-sora_exporter_turn_tcp_connections_total 444
-# HELP sora_exporter_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_exporter_turn_udp_connections_total counter
-sora_exporter_turn_udp_connections_total 555
+# HELP sora_average_duration_seconds The average connection duration in seconds.
+# TYPE sora_average_duration_seconds gauge
+sora_average_duration_seconds 706
+# HELP sora_average_setup_time_seconds The average setup time in seconds.
+# TYPE sora_average_setup_time_seconds gauge
+sora_average_setup_time_seconds 12
+# HELP sora_connections_created_total The total number of connections created.
+# TYPE sora_connections_created_total counter
+sora_connections_created_total 3
+# HELP sora_connections_destroyed_total The total number of connections destryed.
+# TYPE sora_connections_destroyed_total counter
+sora_connections_destroyed_total 2
+# HELP sora_connections_updated_total The total number of connections updated.
+# TYPE sora_connections_updated_total counter
+sora_connections_updated_total 23
+# HELP sora_duration_seconds_total The total duration of connections.
+# TYPE sora_duration_seconds_total counter
+sora_duration_seconds_total 1412
+# HELP sora_failed_connections_total The total number of failed connections.
+# TYPE sora_failed_connections_total counter
+sora_failed_connections_total 100
+# HELP sora_ongoing_connections_total The total number of ongoing connections.
+# TYPE sora_ongoing_connections_total gauge
+sora_ongoing_connections_total 88
+# HELP sora_sora_version_info sora version info.
+# TYPE sora_sora_version_info gauge
+sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_successfull_connections_total The total number of successfull connections.
+# TYPE sora_successfull_connections_total counter
+sora_successfull_connections_total 333
+# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
+# TYPE sora_total_received_invalid_turn_tcp_packet counter
+sora_total_received_invalid_turn_tcp_packet 123
+# HELP sora_total_session_created The total number of session created.
+# TYPE sora_total_session_created counter
+sora_total_session_created 111
+# HELP sora_total_session_destroyed The total number of session destroyed.
+# TYPE sora_total_session_destroyed counter
+sora_total_session_destroyed 222
+# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
+# TYPE sora_turn_tcp_connections_total counter
+sora_turn_tcp_connections_total 444
+# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
+# TYPE sora_turn_udp_connections_total counter
+sora_turn_udp_connections_total 555

--- a/test/sora_client_enabled.metrics
+++ b/test/sora_client_enabled.metrics
@@ -4,81 +4,47 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 0
-# HELP sora_connections_created_total The total number of connections created.
-# TYPE sora_connections_created_total counter
-sora_connections_created_total 2
-# HELP sora_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_connections_destroyed_total counter
-sora_connections_destroyed_total 2
-# HELP sora_connections_updated_total The total number of connections updated.
-# TYPE sora_connections_updated_total counter
-sora_connections_updated_total 23
+# HELP sora_connections_total The total number of connections created.
+# TYPE sora_connections_total counter
+sora_connections_total{state="created"} 2
+sora_connections_total{state="destroyed"} 2
+sora_connections_total{state="failed"} 0
+sora_connections_total{state="successful"} 2
+sora_connections_total{state="updated"} 23
 # HELP sora_duration_seconds_total The total duration of connections.
 # TYPE sora_duration_seconds_total counter
 sora_duration_seconds_total 1412
-# HELP sora_failed_connections_total The total number of failed connections.
-# TYPE sora_failed_connections_total counter
-sora_failed_connections_total 0
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 0
-# HELP sora_client_type_known_successful_total The total number of successful connections for unknown client
-# TYPE sora_client_type_known_successful_total counter
-sora_client_type_known_successful_total 55
-# HELP sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
-# TYPE sora_client_type_sora_android_sdk_failed_total counter
-sora_client_type_sora_android_sdk_failed_total 1
-# HELP sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
-# TYPE sora_client_type_sora_android_sdk_successful_total counter
-sora_client_type_sora_android_sdk_successful_total 11
-# HELP sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
-# TYPE sora_client_type_sora_ios_sdk_failed_total counter
-sora_client_type_sora_ios_sdk_failed_total 2
-# HELP sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
-# TYPE sora_client_type_sora_ios_sdk_successful_total counter
-sora_client_type_sora_ios_sdk_successful_total 22
-# HELP sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
-# TYPE sora_client_type_sora_js_sdk_failed_total counter
-sora_client_type_sora_js_sdk_failed_total 3
-# HELP sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
-# TYPE sora_client_type_sora_js_sdk_successful_total counter
-sora_client_type_sora_js_sdk_successful_total 33
-# HELP sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
-# TYPE sora_client_type_sora_unity_sdk_failed_total counter
-sora_client_type_sora_unity_sdk_failed_total 4
-# HELP sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
-# TYPE sora_client_type_sora_unity_sdk_successful_total counter
-sora_client_type_sora_unity_sdk_successful_total 44
-# HELP sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_client_type_unknown_failed_total counter
-sora_client_type_unknown_failed_total 5
-# HELP sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
-# TYPE sora_client_type_webrtc_native_client_momo_successful_total counter
-sora_client_type_webrtc_native_client_momo_successful_total 66
-# HELP sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_client_type_webrtc_native_client_monmo_failed_total counter
-sora_client_type_webrtc_native_client_monmo_failed_total 6
-# HELP sora_version_info sora version info.
-# TYPE sora_version_info gauge
-sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_successfull_connections_total The total number of successfull connections.
-# TYPE sora_successfull_connections_total counter
-sora_successfull_connections_total 2
-# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_total_received_invalid_turn_tcp_packet counter
-sora_total_received_invalid_turn_tcp_packet 0
-# HELP sora_total_session_created The total number of session created.
-# TYPE sora_total_session_created counter
-sora_total_session_created 1
-# HELP sora_total_session_destroyed The total number of session destroyed.
-# TYPE sora_total_session_destroyed counter
-sora_total_session_destroyed 0
-# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_turn_tcp_connections_total counter
-sora_turn_tcp_connections_total 2
-# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_turn_udp_connections_total counter
-sora_turn_udp_connections_total 0
+# HELP sora_received_invalid_turn_tcp_packet_total The total number of invalid packets with TURN-TCP
+# TYPE sora_received_invalid_turn_tcp_packet_total counter
+sora_received_invalid_turn_tcp_packet_total 0
+# HELP sora_session_total The total number of session.
+# TYPE sora_session_total counter
+sora_session_total{state="created"} 1
+sora_session_total{state="destroyed"} 0
+# HELP sora_sora_client_connections_total The total number of connections by Sora client types
+# TYPE sora_sora_client_connections_total counter
+sora_sora_client_connections_total{state="failed",type="android_sdk"} 1
+sora_sora_client_connections_total{state="failed",type="ios_sdk"} 2
+sora_sora_client_connections_total{state="failed",type="js_sdk"} 3
+sora_sora_client_connections_total{state="failed",type="momo"} 6
+sora_sora_client_connections_total{state="failed",type="unity_sdk"} 4
+sora_sora_client_connections_total{state="failed",type="unknown"} 5
+sora_sora_client_connections_total{state="successful",type="android_sdk"} 11
+sora_sora_client_connections_total{state="successful",type="ios_sdk"} 22
+sora_sora_client_connections_total{state="successful",type="js_sdk"} 33
+sora_sora_client_connections_total{state="successful",type="momo"} 66
+sora_sora_client_connections_total{state="successful",type="unity_sdk"} 44
+sora_sora_client_connections_total{state="successful",type="unknown"} 55
+# HELP sora_turn_connections_total The total number of connections with TURN.
+# TYPE sora_turn_connections_total counter
+sora_turn_connections_total{proto="tcp"} 2
+sora_turn_connections_total{proto="udp"} 0
 # HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
 # TYPE sora_up gauge
 sora_up 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1

--- a/test/sora_client_enabled.metrics
+++ b/test/sora_client_enabled.metrics
@@ -1,81 +1,81 @@
-# HELP sora_exporter_average_duration_seconds The average connection duration in seconds.
-# TYPE sora_exporter_average_duration_seconds gauge
-sora_exporter_average_duration_seconds 706
-# HELP sora_exporter_average_setup_time_seconds The average setup time in seconds.
-# TYPE sora_exporter_average_setup_time_seconds gauge
-sora_exporter_average_setup_time_seconds 0
-# HELP sora_exporter_connections_created_total The total number of connections created.
-# TYPE sora_exporter_connections_created_total counter
-sora_exporter_connections_created_total 2
-# HELP sora_exporter_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_exporter_connections_destroyed_total counter
-sora_exporter_connections_destroyed_total 2
-# HELP sora_exporter_connections_updated_total The total number of connections updated.
-# TYPE sora_exporter_connections_updated_total counter
-sora_exporter_connections_updated_total 23
-# HELP sora_exporter_duration_seconds_total The total duration of connections.
-# TYPE sora_exporter_duration_seconds_total counter
-sora_exporter_duration_seconds_total 1412
-# HELP sora_exporter_failed_connections_total The total number of failed connections.
-# TYPE sora_exporter_failed_connections_total counter
-sora_exporter_failed_connections_total 0
-# HELP sora_exporter_ongoing_connections_total The total number of ongoing connections.
-# TYPE sora_exporter_ongoing_connections_total gauge
-sora_exporter_ongoing_connections_total 0
-# HELP sora_exporter_sora_client_type_known_successful_total The total number of successful connections for unknown client
-# TYPE sora_exporter_sora_client_type_known_successful_total counter
-sora_exporter_sora_client_type_known_successful_total 55
-# HELP sora_exporter_sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
-# TYPE sora_exporter_sora_client_type_sora_android_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_android_sdk_failed_total 1
-# HELP sora_exporter_sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
-# TYPE sora_exporter_sora_client_type_sora_android_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_android_sdk_successful_total 11
-# HELP sora_exporter_sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
-# TYPE sora_exporter_sora_client_type_sora_ios_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_ios_sdk_failed_total 2
-# HELP sora_exporter_sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
-# TYPE sora_exporter_sora_client_type_sora_ios_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_ios_sdk_successful_total 22
-# HELP sora_exporter_sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
-# TYPE sora_exporter_sora_client_type_sora_js_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_js_sdk_failed_total 3
-# HELP sora_exporter_sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
-# TYPE sora_exporter_sora_client_type_sora_js_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_js_sdk_successful_total 33
-# HELP sora_exporter_sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
-# TYPE sora_exporter_sora_client_type_sora_unity_sdk_failed_total counter
-sora_exporter_sora_client_type_sora_unity_sdk_failed_total 4
-# HELP sora_exporter_sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
-# TYPE sora_exporter_sora_client_type_sora_unity_sdk_successful_total counter
-sora_exporter_sora_client_type_sora_unity_sdk_successful_total 44
-# HELP sora_exporter_sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_exporter_sora_client_type_unknown_failed_total counter
-sora_exporter_sora_client_type_unknown_failed_total 5
-# HELP sora_exporter_sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
-# TYPE sora_exporter_sora_client_type_webrtc_native_client_momo_successful_total counter
-sora_exporter_sora_client_type_webrtc_native_client_momo_successful_total 66
-# HELP sora_exporter_sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_exporter_sora_client_type_webrtc_native_client_monmo_failed_total counter
-sora_exporter_sora_client_type_webrtc_native_client_monmo_failed_total 6
-# HELP sora_exporter_sora_version_info sora version info.
-# TYPE sora_exporter_sora_version_info gauge
-sora_exporter_sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_exporter_successfull_connections_total The total number of successfull connections.
-# TYPE sora_exporter_successfull_connections_total counter
-sora_exporter_successfull_connections_total 2
-# HELP sora_exporter_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_exporter_total_received_invalid_turn_tcp_packet counter
-sora_exporter_total_received_invalid_turn_tcp_packet 0
-# HELP sora_exporter_total_session_created The total number of session created.
-# TYPE sora_exporter_total_session_created counter
-sora_exporter_total_session_created 1
-# HELP sora_exporter_total_session_destroyed The total number of session destroyed.
-# TYPE sora_exporter_total_session_destroyed counter
-sora_exporter_total_session_destroyed 0
-# HELP sora_exporter_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_exporter_turn_tcp_connections_total counter
-sora_exporter_turn_tcp_connections_total 2
-# HELP sora_exporter_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_exporter_turn_udp_connections_total counter
-sora_exporter_turn_udp_connections_total 0
+# HELP sora_average_duration_seconds The average connection duration in seconds.
+# TYPE sora_average_duration_seconds gauge
+sora_average_duration_seconds 706
+# HELP sora_average_setup_time_seconds The average setup time in seconds.
+# TYPE sora_average_setup_time_seconds gauge
+sora_average_setup_time_seconds 0
+# HELP sora_connections_created_total The total number of connections created.
+# TYPE sora_connections_created_total counter
+sora_connections_created_total 2
+# HELP sora_connections_destroyed_total The total number of connections destryed.
+# TYPE sora_connections_destroyed_total counter
+sora_connections_destroyed_total 2
+# HELP sora_connections_updated_total The total number of connections updated.
+# TYPE sora_connections_updated_total counter
+sora_connections_updated_total 23
+# HELP sora_duration_seconds_total The total duration of connections.
+# TYPE sora_duration_seconds_total counter
+sora_duration_seconds_total 1412
+# HELP sora_failed_connections_total The total number of failed connections.
+# TYPE sora_failed_connections_total counter
+sora_failed_connections_total 0
+# HELP sora_ongoing_connections_total The total number of ongoing connections.
+# TYPE sora_ongoing_connections_total gauge
+sora_ongoing_connections_total 0
+# HELP sora_sora_client_type_known_successful_total The total number of successful connections for unknown client
+# TYPE sora_sora_client_type_known_successful_total counter
+sora_sora_client_type_known_successful_total 55
+# HELP sora_sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
+# TYPE sora_sora_client_type_sora_android_sdk_failed_total counter
+sora_sora_client_type_sora_android_sdk_failed_total 1
+# HELP sora_sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
+# TYPE sora_sora_client_type_sora_android_sdk_successful_total counter
+sora_sora_client_type_sora_android_sdk_successful_total 11
+# HELP sora_sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
+# TYPE sora_sora_client_type_sora_ios_sdk_failed_total counter
+sora_sora_client_type_sora_ios_sdk_failed_total 2
+# HELP sora_sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
+# TYPE sora_sora_client_type_sora_ios_sdk_successful_total counter
+sora_sora_client_type_sora_ios_sdk_successful_total 22
+# HELP sora_sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
+# TYPE sora_sora_client_type_sora_js_sdk_failed_total counter
+sora_sora_client_type_sora_js_sdk_failed_total 3
+# HELP sora_sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
+# TYPE sora_sora_client_type_sora_js_sdk_successful_total counter
+sora_sora_client_type_sora_js_sdk_successful_total 33
+# HELP sora_sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
+# TYPE sora_sora_client_type_sora_unity_sdk_failed_total counter
+sora_sora_client_type_sora_unity_sdk_failed_total 4
+# HELP sora_sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
+# TYPE sora_sora_client_type_sora_unity_sdk_successful_total counter
+sora_sora_client_type_sora_unity_sdk_successful_total 44
+# HELP sora_sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_sora_client_type_unknown_failed_total counter
+sora_sora_client_type_unknown_failed_total 5
+# HELP sora_sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
+# TYPE sora_sora_client_type_webrtc_native_client_momo_successful_total counter
+sora_sora_client_type_webrtc_native_client_momo_successful_total 66
+# HELP sora_sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_sora_client_type_webrtc_native_client_monmo_failed_total counter
+sora_sora_client_type_webrtc_native_client_monmo_failed_total 6
+# HELP sora_sora_version_info sora version info.
+# TYPE sora_sora_version_info gauge
+sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_successfull_connections_total The total number of successfull connections.
+# TYPE sora_successfull_connections_total counter
+sora_successfull_connections_total 2
+# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
+# TYPE sora_total_received_invalid_turn_tcp_packet counter
+sora_total_received_invalid_turn_tcp_packet 0
+# HELP sora_total_session_created The total number of session created.
+# TYPE sora_total_session_created counter
+sora_total_session_created 1
+# HELP sora_total_session_destroyed The total number of session destroyed.
+# TYPE sora_total_session_destroyed counter
+sora_total_session_destroyed 0
+# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
+# TYPE sora_turn_tcp_connections_total counter
+sora_turn_tcp_connections_total 2
+# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
+# TYPE sora_turn_udp_connections_total counter
+sora_turn_udp_connections_total 0

--- a/test/sora_client_enabled.metrics
+++ b/test/sora_client_enabled.metrics
@@ -4,6 +4,20 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 0
+# HELP sora_client_type_total The total number of connections by Sora client types
+# TYPE sora_client_type_total counter
+sora_client_type_total{client="android_sdk",state="failed"} 1
+sora_client_type_total{client="android_sdk",state="successful"} 11
+sora_client_type_total{client="ios_sdk",state="failed"} 2
+sora_client_type_total{client="ios_sdk",state="successful"} 22
+sora_client_type_total{client="js_sdk",state="failed"} 3
+sora_client_type_total{client="js_sdk",state="successful"} 33
+sora_client_type_total{client="momo",state="failed"} 6
+sora_client_type_total{client="momo",state="successful"} 66
+sora_client_type_total{client="unity_sdk",state="failed"} 4
+sora_client_type_total{client="unity_sdk",state="successful"} 44
+sora_client_type_total{client="unknown",state="failed"} 5
+sora_client_type_total{client="unknown",state="successful"} 55
 # HELP sora_connections_total The total number of connections created.
 # TYPE sora_connections_total counter
 sora_connections_total{state="created"} 2
@@ -24,20 +38,6 @@ sora_received_invalid_turn_tcp_packet_total 0
 # TYPE sora_session_total counter
 sora_session_total{state="created"} 1
 sora_session_total{state="destroyed"} 0
-# HELP sora_sora_client_connections_total The total number of connections by Sora client types
-# TYPE sora_sora_client_connections_total counter
-sora_sora_client_connections_total{state="failed",type="android_sdk"} 1
-sora_sora_client_connections_total{state="failed",type="ios_sdk"} 2
-sora_sora_client_connections_total{state="failed",type="js_sdk"} 3
-sora_sora_client_connections_total{state="failed",type="momo"} 6
-sora_sora_client_connections_total{state="failed",type="unity_sdk"} 4
-sora_sora_client_connections_total{state="failed",type="unknown"} 5
-sora_sora_client_connections_total{state="successful",type="android_sdk"} 11
-sora_sora_client_connections_total{state="successful",type="ios_sdk"} 22
-sora_sora_client_connections_total{state="successful",type="js_sdk"} 33
-sora_sora_client_connections_total{state="successful",type="momo"} 66
-sora_sora_client_connections_total{state="successful",type="unity_sdk"} 44
-sora_sora_client_connections_total{state="successful",type="unknown"} 55
 # HELP sora_turn_connections_total The total number of connections with TURN.
 # TYPE sora_turn_connections_total counter
 sora_turn_connections_total{proto="tcp"} 2

--- a/test/sora_client_enabled.metrics
+++ b/test/sora_client_enabled.metrics
@@ -79,3 +79,6 @@ sora_turn_tcp_connections_total 2
 # HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
 # TYPE sora_turn_udp_connections_total counter
 sora_turn_udp_connections_total 0
+# HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
+# TYPE sora_up gauge
+sora_up 1

--- a/test/sora_client_enabled.metrics
+++ b/test/sora_client_enabled.metrics
@@ -22,45 +22,45 @@ sora_failed_connections_total 0
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 0
-# HELP sora_sora_client_type_known_successful_total The total number of successful connections for unknown client
-# TYPE sora_sora_client_type_known_successful_total counter
-sora_sora_client_type_known_successful_total 55
-# HELP sora_sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
-# TYPE sora_sora_client_type_sora_android_sdk_failed_total counter
-sora_sora_client_type_sora_android_sdk_failed_total 1
-# HELP sora_sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
-# TYPE sora_sora_client_type_sora_android_sdk_successful_total counter
-sora_sora_client_type_sora_android_sdk_successful_total 11
-# HELP sora_sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
-# TYPE sora_sora_client_type_sora_ios_sdk_failed_total counter
-sora_sora_client_type_sora_ios_sdk_failed_total 2
-# HELP sora_sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
-# TYPE sora_sora_client_type_sora_ios_sdk_successful_total counter
-sora_sora_client_type_sora_ios_sdk_successful_total 22
-# HELP sora_sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
-# TYPE sora_sora_client_type_sora_js_sdk_failed_total counter
-sora_sora_client_type_sora_js_sdk_failed_total 3
-# HELP sora_sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
-# TYPE sora_sora_client_type_sora_js_sdk_successful_total counter
-sora_sora_client_type_sora_js_sdk_successful_total 33
-# HELP sora_sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
-# TYPE sora_sora_client_type_sora_unity_sdk_failed_total counter
-sora_sora_client_type_sora_unity_sdk_failed_total 4
-# HELP sora_sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
-# TYPE sora_sora_client_type_sora_unity_sdk_successful_total counter
-sora_sora_client_type_sora_unity_sdk_successful_total 44
-# HELP sora_sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_sora_client_type_unknown_failed_total counter
-sora_sora_client_type_unknown_failed_total 5
-# HELP sora_sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
-# TYPE sora_sora_client_type_webrtc_native_client_momo_successful_total counter
-sora_sora_client_type_webrtc_native_client_momo_successful_total 66
-# HELP sora_sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
-# TYPE sora_sora_client_type_webrtc_native_client_monmo_failed_total counter
-sora_sora_client_type_webrtc_native_client_monmo_failed_total 6
-# HELP sora_sora_version_info sora version info.
-# TYPE sora_sora_version_info gauge
-sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_client_type_known_successful_total The total number of successful connections for unknown client
+# TYPE sora_client_type_known_successful_total counter
+sora_client_type_known_successful_total 55
+# HELP sora_client_type_sora_android_sdk_failed_total The total number of failed connections for Sora Android SDK.
+# TYPE sora_client_type_sora_android_sdk_failed_total counter
+sora_client_type_sora_android_sdk_failed_total 1
+# HELP sora_client_type_sora_android_sdk_successful_total The total number of successful connections for Sora Android SDK.
+# TYPE sora_client_type_sora_android_sdk_successful_total counter
+sora_client_type_sora_android_sdk_successful_total 11
+# HELP sora_client_type_sora_ios_sdk_failed_total The total number of failed connections for Sora IOS SDK.
+# TYPE sora_client_type_sora_ios_sdk_failed_total counter
+sora_client_type_sora_ios_sdk_failed_total 2
+# HELP sora_client_type_sora_ios_sdk_successful_total The total number of successful connections for Sora IOS SDK.
+# TYPE sora_client_type_sora_ios_sdk_successful_total counter
+sora_client_type_sora_ios_sdk_successful_total 22
+# HELP sora_client_type_sora_js_sdk_failed_total The total number of failed connections for Sora JavaScript SDK.
+# TYPE sora_client_type_sora_js_sdk_failed_total counter
+sora_client_type_sora_js_sdk_failed_total 3
+# HELP sora_client_type_sora_js_sdk_successful_total The total number of successful connections for Sora JavaScript SDK.
+# TYPE sora_client_type_sora_js_sdk_successful_total counter
+sora_client_type_sora_js_sdk_successful_total 33
+# HELP sora_client_type_sora_unity_sdk_failed_total The total number of failed connections for Sora Unity SDK.
+# TYPE sora_client_type_sora_unity_sdk_failed_total counter
+sora_client_type_sora_unity_sdk_failed_total 4
+# HELP sora_client_type_sora_unity_sdk_successful_total The total number of successful connections for Sora Unity SDK.
+# TYPE sora_client_type_sora_unity_sdk_successful_total counter
+sora_client_type_sora_unity_sdk_successful_total 44
+# HELP sora_client_type_unknown_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_client_type_unknown_failed_total counter
+sora_client_type_unknown_failed_total 5
+# HELP sora_client_type_webrtc_native_client_momo_successful_total The total number of successful connections for WebRTC native client Momo.
+# TYPE sora_client_type_webrtc_native_client_momo_successful_total counter
+sora_client_type_webrtc_native_client_momo_successful_total 66
+# HELP sora_client_type_webrtc_native_client_monmo_failed_total The total number of failed connections for WebRTC native client Momo.
+# TYPE sora_client_type_webrtc_native_client_monmo_failed_total counter
+sora_client_type_webrtc_native_client_monmo_failed_total 6
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1
 # HELP sora_successfull_connections_total The total number of successfull connections.
 # TYPE sora_successfull_connections_total counter
 sora_successfull_connections_total 2

--- a/test/sora_connection_error_enabled.metrics
+++ b/test/sora_connection_error_enabled.metrics
@@ -28,9 +28,9 @@ sora_sdp_generation_error_total 3
 # HELP sora_signaling_error_total The total number of signaling error.
 # TYPE sora_signaling_error_total counter
 sora_signaling_error_total 4
-# HELP sora_sora_version_info sora version info.
-# TYPE sora_sora_version_info gauge
-sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1
 # HELP sora_successfull_connections_total The total number of successfull connections.
 # TYPE sora_successfull_connections_total counter
 sora_successfull_connections_total 2

--- a/test/sora_connection_error_enabled.metrics
+++ b/test/sora_connection_error_enabled.metrics
@@ -1,51 +1,51 @@
-# HELP sora_exporter_average_duration_seconds The average connection duration in seconds.
-# TYPE sora_exporter_average_duration_seconds gauge
-sora_exporter_average_duration_seconds 706
-# HELP sora_exporter_average_setup_time_seconds The average setup time in seconds.
-# TYPE sora_exporter_average_setup_time_seconds gauge
-sora_exporter_average_setup_time_seconds 0
-# HELP sora_exporter_connections_created_total The total number of connections created.
-# TYPE sora_exporter_connections_created_total counter
-sora_exporter_connections_created_total 2
-# HELP sora_exporter_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_exporter_connections_destroyed_total counter
-sora_exporter_connections_destroyed_total 2
-# HELP sora_exporter_connections_updated_total The total number of connections updated.
-# TYPE sora_exporter_connections_updated_total counter
-sora_exporter_connections_updated_total 23
-# HELP sora_exporter_duration_seconds_total The total duration of connections.
-# TYPE sora_exporter_duration_seconds_total counter
-sora_exporter_duration_seconds_total 1412
-# HELP sora_exporter_failed_connections_total The total number of failed connections.
-# TYPE sora_exporter_failed_connections_total counter
-sora_exporter_failed_connections_total 0
-# HELP sora_exporter_ongoing_connections_total The total number of ongoing connections.
-# TYPE sora_exporter_ongoing_connections_total gauge
-sora_exporter_ongoing_connections_total 0
-# HELP sora_exporter_sdp_generation_error_total The total number of SDP genration error.
-# TYPE sora_exporter_sdp_generation_error_total counter
-sora_exporter_sdp_generation_error_total 3
-# HELP sora_exporter_signaling_error_total The total number of signaling error.
-# TYPE sora_exporter_signaling_error_total counter
-sora_exporter_signaling_error_total 4
-# HELP sora_exporter_sora_version_info sora version info.
-# TYPE sora_exporter_sora_version_info gauge
-sora_exporter_sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_exporter_successfull_connections_total The total number of successfull connections.
-# TYPE sora_exporter_successfull_connections_total counter
-sora_exporter_successfull_connections_total 2
-# HELP sora_exporter_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_exporter_total_received_invalid_turn_tcp_packet counter
-sora_exporter_total_received_invalid_turn_tcp_packet 0
-# HELP sora_exporter_total_session_created The total number of session created.
-# TYPE sora_exporter_total_session_created counter
-sora_exporter_total_session_created 1
-# HELP sora_exporter_total_session_destroyed The total number of session destroyed.
-# TYPE sora_exporter_total_session_destroyed counter
-sora_exporter_total_session_destroyed 0
-# HELP sora_exporter_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_exporter_turn_tcp_connections_total counter
-sora_exporter_turn_tcp_connections_total 2
-# HELP sora_exporter_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_exporter_turn_udp_connections_total counter
-sora_exporter_turn_udp_connections_total 0
+# HELP sora_average_duration_seconds The average connection duration in seconds.
+# TYPE sora_average_duration_seconds gauge
+sora_average_duration_seconds 706
+# HELP sora_average_setup_time_seconds The average setup time in seconds.
+# TYPE sora_average_setup_time_seconds gauge
+sora_average_setup_time_seconds 0
+# HELP sora_connections_created_total The total number of connections created.
+# TYPE sora_connections_created_total counter
+sora_connections_created_total 2
+# HELP sora_connections_destroyed_total The total number of connections destryed.
+# TYPE sora_connections_destroyed_total counter
+sora_connections_destroyed_total 2
+# HELP sora_connections_updated_total The total number of connections updated.
+# TYPE sora_connections_updated_total counter
+sora_connections_updated_total 23
+# HELP sora_duration_seconds_total The total duration of connections.
+# TYPE sora_duration_seconds_total counter
+sora_duration_seconds_total 1412
+# HELP sora_failed_connections_total The total number of failed connections.
+# TYPE sora_failed_connections_total counter
+sora_failed_connections_total 0
+# HELP sora_ongoing_connections_total The total number of ongoing connections.
+# TYPE sora_ongoing_connections_total gauge
+sora_ongoing_connections_total 0
+# HELP sora_sdp_generation_error_total The total number of SDP genration error.
+# TYPE sora_sdp_generation_error_total counter
+sora_sdp_generation_error_total 3
+# HELP sora_signaling_error_total The total number of signaling error.
+# TYPE sora_signaling_error_total counter
+sora_signaling_error_total 4
+# HELP sora_sora_version_info sora version info.
+# TYPE sora_sora_version_info gauge
+sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_successfull_connections_total The total number of successfull connections.
+# TYPE sora_successfull_connections_total counter
+sora_successfull_connections_total 2
+# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
+# TYPE sora_total_received_invalid_turn_tcp_packet counter
+sora_total_received_invalid_turn_tcp_packet 0
+# HELP sora_total_session_created The total number of session created.
+# TYPE sora_total_session_created counter
+sora_total_session_created 1
+# HELP sora_total_session_destroyed The total number of session destroyed.
+# TYPE sora_total_session_destroyed counter
+sora_total_session_destroyed 0
+# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
+# TYPE sora_turn_tcp_connections_total counter
+sora_turn_tcp_connections_total 2
+# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
+# TYPE sora_turn_udp_connections_total counter
+sora_turn_udp_connections_total 0

--- a/test/sora_connection_error_enabled.metrics
+++ b/test/sora_connection_error_enabled.metrics
@@ -49,3 +49,6 @@ sora_turn_tcp_connections_total 2
 # HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
 # TYPE sora_turn_udp_connections_total counter
 sora_turn_udp_connections_total 0
+# HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
+# TYPE sora_up gauge
+sora_up 1

--- a/test/sora_connection_error_enabled.metrics
+++ b/test/sora_connection_error_enabled.metrics
@@ -4,51 +4,37 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 0
-# HELP sora_connections_created_total The total number of connections created.
-# TYPE sora_connections_created_total counter
-sora_connections_created_total 2
-# HELP sora_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_connections_destroyed_total counter
-sora_connections_destroyed_total 2
-# HELP sora_connections_updated_total The total number of connections updated.
-# TYPE sora_connections_updated_total counter
-sora_connections_updated_total 23
+# HELP sora_connection_error_total The total number of connection error.
+# TYPE sora_connection_error_total counter
+sora_connection_error_total{reason="sdp"} 3
+sora_connection_error_total{reason="signaling"} 4
+# HELP sora_connections_total The total number of connections created.
+# TYPE sora_connections_total counter
+sora_connections_total{state="created"} 2
+sora_connections_total{state="destroyed"} 2
+sora_connections_total{state="failed"} 0
+sora_connections_total{state="successful"} 2
+sora_connections_total{state="updated"} 23
 # HELP sora_duration_seconds_total The total duration of connections.
 # TYPE sora_duration_seconds_total counter
 sora_duration_seconds_total 1412
-# HELP sora_failed_connections_total The total number of failed connections.
-# TYPE sora_failed_connections_total counter
-sora_failed_connections_total 0
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 0
-# HELP sora_sdp_generation_error_total The total number of SDP genration error.
-# TYPE sora_sdp_generation_error_total counter
-sora_sdp_generation_error_total 3
-# HELP sora_signaling_error_total The total number of signaling error.
-# TYPE sora_signaling_error_total counter
-sora_signaling_error_total 4
-# HELP sora_version_info sora version info.
-# TYPE sora_version_info gauge
-sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_successfull_connections_total The total number of successfull connections.
-# TYPE sora_successfull_connections_total counter
-sora_successfull_connections_total 2
-# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_total_received_invalid_turn_tcp_packet counter
-sora_total_received_invalid_turn_tcp_packet 0
-# HELP sora_total_session_created The total number of session created.
-# TYPE sora_total_session_created counter
-sora_total_session_created 1
-# HELP sora_total_session_destroyed The total number of session destroyed.
-# TYPE sora_total_session_destroyed counter
-sora_total_session_destroyed 0
-# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_turn_tcp_connections_total counter
-sora_turn_tcp_connections_total 2
-# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_turn_udp_connections_total counter
-sora_turn_udp_connections_total 0
+# HELP sora_received_invalid_turn_tcp_packet_total The total number of invalid packets with TURN-TCP
+# TYPE sora_received_invalid_turn_tcp_packet_total counter
+sora_received_invalid_turn_tcp_packet_total 0
+# HELP sora_session_total The total number of session.
+# TYPE sora_session_total counter
+sora_session_total{state="created"} 1
+sora_session_total{state="destroyed"} 0
+# HELP sora_turn_connections_total The total number of connections with TURN.
+# TYPE sora_turn_connections_total counter
+sora_turn_connections_total{proto="tcp"} 2
+sora_turn_connections_total{proto="udp"} 0
 # HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
 # TYPE sora_up gauge
 sora_up 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1

--- a/test/sora_erlang_vm_enabled.metrics
+++ b/test/sora_erlang_vm_enabled.metrics
@@ -103,9 +103,9 @@ sora_failed_connections_total 0
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 0
-# HELP sora_sora_version_info sora version info.
-# TYPE sora_sora_version_info gauge
-sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1
 # HELP sora_successfull_connections_total The total number of successfull connections.
 # TYPE sora_successfull_connections_total counter
 sora_successfull_connections_total 2

--- a/test/sora_erlang_vm_enabled.metrics
+++ b/test/sora_erlang_vm_enabled.metrics
@@ -124,3 +124,6 @@ sora_turn_tcp_connections_total 2
 # HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
 # TYPE sora_turn_udp_connections_total counter
 sora_turn_udp_connections_total 0
+# HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
+# TYPE sora_up gauge
+sora_up 1

--- a/test/sora_erlang_vm_enabled.metrics
+++ b/test/sora_erlang_vm_enabled.metrics
@@ -4,15 +4,13 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 0
-# HELP sora_connections_created_total The total number of connections created.
-# TYPE sora_connections_created_total counter
-sora_connections_created_total 2
-# HELP sora_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_connections_destroyed_total counter
-sora_connections_destroyed_total 2
-# HELP sora_connections_updated_total The total number of connections updated.
-# TYPE sora_connections_updated_total counter
-sora_connections_updated_total 23
+# HELP sora_connections_total The total number of connections created.
+# TYPE sora_connections_total counter
+sora_connections_total{state="created"} 2
+sora_connections_total{state="destroyed"} 2
+sora_connections_total{state="failed"} 0
+sora_connections_total{state="successful"} 2
+sora_connections_total{state="updated"} 23
 # HELP sora_duration_seconds_total The total duration of connections.
 # TYPE sora_duration_seconds_total counter
 sora_duration_seconds_total 1412
@@ -97,33 +95,23 @@ sora_erlang_vm_wall_clock_total_wallclock_time 994
 # HELP sora_erlang_vm_wall_clock_wallclock_time_since_last_call The number of information about wall clock since last call.
 # TYPE sora_erlang_vm_wall_clock_wallclock_time_since_last_call gauge
 sora_erlang_vm_wall_clock_wallclock_time_since_last_call 9090
-# HELP sora_failed_connections_total The total number of failed connections.
-# TYPE sora_failed_connections_total counter
-sora_failed_connections_total 0
 # HELP sora_ongoing_connections_total The total number of ongoing connections.
 # TYPE sora_ongoing_connections_total gauge
 sora_ongoing_connections_total 0
-# HELP sora_version_info sora version info.
-# TYPE sora_version_info gauge
-sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_successfull_connections_total The total number of successfull connections.
-# TYPE sora_successfull_connections_total counter
-sora_successfull_connections_total 2
-# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_total_received_invalid_turn_tcp_packet counter
-sora_total_received_invalid_turn_tcp_packet 0
-# HELP sora_total_session_created The total number of session created.
-# TYPE sora_total_session_created counter
-sora_total_session_created 1
-# HELP sora_total_session_destroyed The total number of session destroyed.
-# TYPE sora_total_session_destroyed counter
-sora_total_session_destroyed 0
-# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_turn_tcp_connections_total counter
-sora_turn_tcp_connections_total 2
-# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_turn_udp_connections_total counter
-sora_turn_udp_connections_total 0
+# HELP sora_received_invalid_turn_tcp_packet_total The total number of invalid packets with TURN-TCP
+# TYPE sora_received_invalid_turn_tcp_packet_total counter
+sora_received_invalid_turn_tcp_packet_total 0
+# HELP sora_session_total The total number of session.
+# TYPE sora_session_total counter
+sora_session_total{state="created"} 1
+sora_session_total{state="destroyed"} 0
+# HELP sora_turn_connections_total The total number of connections with TURN.
+# TYPE sora_turn_connections_total counter
+sora_turn_connections_total{proto="tcp"} 2
+sora_turn_connections_total{proto="udp"} 0
 # HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
 # TYPE sora_up gauge
 sora_up 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1

--- a/test/sora_erlang_vm_enabled.metrics
+++ b/test/sora_erlang_vm_enabled.metrics
@@ -1,126 +1,126 @@
-# HELP sora_exporter_average_duration_seconds The average connection duration in seconds.
-# TYPE sora_exporter_average_duration_seconds gauge
-sora_exporter_average_duration_seconds 706
-# HELP sora_exporter_average_setup_time_seconds The average setup time in seconds.
-# TYPE sora_exporter_average_setup_time_seconds gauge
-sora_exporter_average_setup_time_seconds 0
-# HELP sora_exporter_connections_created_total The total number of connections created.
-# TYPE sora_exporter_connections_created_total counter
-sora_exporter_connections_created_total 2
-# HELP sora_exporter_connections_destroyed_total The total number of connections destryed.
-# TYPE sora_exporter_connections_destroyed_total counter
-sora_exporter_connections_destroyed_total 2
-# HELP sora_exporter_connections_updated_total The total number of connections updated.
-# TYPE sora_exporter_connections_updated_total counter
-sora_exporter_connections_updated_total 23
-# HELP sora_exporter_duration_seconds_total The total duration of connections.
-# TYPE sora_exporter_duration_seconds_total counter
-sora_exporter_duration_seconds_total 1412
-# HELP sora_exporter_erlang_vm_context_switches The total number of context switches since the system started.
-# TYPE sora_exporter_erlang_vm_context_switches counter
-sora_exporter_erlang_vm_context_switches 321
-# HELP sora_exporter_erlang_vm_exact_reductions_exact_reductions_since_last_call The number of exact reductions since last call.
-# TYPE sora_exporter_erlang_vm_exact_reductions_exact_reductions_since_last_call gauge
-sora_exporter_erlang_vm_exact_reductions_exact_reductions_since_last_call 213
-# HELP sora_exporter_erlang_vm_exact_reductions_total_exact_reductions The total number of exact reductions.
-# TYPE sora_exporter_erlang_vm_exact_reductions_total_exact_reductions counter
-sora_exporter_erlang_vm_exact_reductions_total_exact_reductions 432
-# HELP sora_exporter_erlang_vm_garbage_collection_number_of_gcs The number of information about garbage collection.
-# TYPE sora_exporter_erlang_vm_garbage_collection_number_of_gcs gauge
-sora_exporter_erlang_vm_garbage_collection_number_of_gcs 912
-# HELP sora_exporter_erlang_vm_garbage_collection_words_reclaimed The number of information about garbage collection word reclaimed.
-# TYPE sora_exporter_erlang_vm_garbage_collection_words_reclaimed gauge
-sora_exporter_erlang_vm_garbage_collection_words_reclaimed 345
-# HELP sora_exporter_erlang_vm_io_input The total number of bytes received through ports.
-# TYPE sora_exporter_erlang_vm_io_input counter
-sora_exporter_erlang_vm_io_input 769
-# HELP sora_exporter_erlang_vm_io_output The total number of bytes output through ports.
-# TYPE sora_exporter_erlang_vm_io_output counter
-sora_exporter_erlang_vm_io_output 331
-# HELP sora_exporter_erlang_vm_memory_atom The total amount of memory currently allocated for atoms. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_atom gauge
-sora_exporter_erlang_vm_memory_atom 3333
-# HELP sora_exporter_erlang_vm_memory_atom_used The total amount of memory currently used for atoms. This memory is part of the memory presented as atom memory.
-# TYPE sora_exporter_erlang_vm_memory_atom_used gauge
-sora_exporter_erlang_vm_memory_atom_used 2222
-# HELP sora_exporter_erlang_vm_memory_binary The total amount of memory currently allocated for binaries. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_binary gauge
-sora_exporter_erlang_vm_memory_binary 1111
-# HELP sora_exporter_erlang_vm_memory_code The total amount of memory currently allocated for Erlang code. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_code gauge
-sora_exporter_erlang_vm_memory_code 777
-# HELP sora_exporter_erlang_vm_memory_ets The total amount of memory currently allocated for ETS tables. This memory is part of the memory presented as system memory.
-# TYPE sora_exporter_erlang_vm_memory_ets gauge
-sora_exporter_erlang_vm_memory_ets 888
-# HELP sora_exporter_erlang_vm_memory_processes The total amount of memory currently allocated for the Erlang processes.
-# TYPE sora_exporter_erlang_vm_memory_processes gauge
-sora_exporter_erlang_vm_memory_processes 5678
-# HELP sora_exporter_erlang_vm_memory_processes_used The total amount of memory currently used by the Erlang processes. This is part of the memory presented as processes memory.
-# TYPE sora_exporter_erlang_vm_memory_processes_used gauge
-sora_exporter_erlang_vm_memory_processes_used 6666
-# HELP sora_exporter_erlang_vm_memory_system The total amount of memory currently allocated for the emulator that is not directly related to any Erlang process. Memory presented as processes is not included in this memory. instrument(3) can be used to get a more detailed breakdown of what memory is part of this type.
-# TYPE sora_exporter_erlang_vm_memory_system gauge
-sora_exporter_erlang_vm_memory_system 4444
-# HELP sora_exporter_erlang_vm_memory_total The total amount of memory currently allocated. This is the same as the sum of the memory size for processes and system.
-# TYPE sora_exporter_erlang_vm_memory_total gauge
-sora_exporter_erlang_vm_memory_total 1234
-# HELP sora_exporter_erlang_vm_reductions_reductions_since_last_call The number of information about reductions.
-# TYPE sora_exporter_erlang_vm_reductions_reductions_since_last_call gauge
-sora_exporter_erlang_vm_reductions_reductions_since_last_call 443
-# HELP sora_exporter_erlang_vm_reductions_total_reductions The total number of information about reductions.
-# TYPE sora_exporter_erlang_vm_reductions_total_reductions counter
-sora_exporter_erlang_vm_reductions_total_reductions 8080
-# HELP sora_exporter_erlang_vm_run_queue The total length of all normal and dirty CPU run queues.
-# TYPE sora_exporter_erlang_vm_run_queue gauge
-sora_exporter_erlang_vm_run_queue 0
-# HELP sora_exporter_erlang_vm_runtime_time_since_last_call The number of information about runtime since last call, in milliseconds.
-# TYPE sora_exporter_erlang_vm_runtime_time_since_last_call gauge
-sora_exporter_erlang_vm_runtime_time_since_last_call 100
-# HELP sora_exporter_erlang_vm_runtime_total_run_time The number of information about runtime, in milliseconds.
-# TYPE sora_exporter_erlang_vm_runtime_total_run_time gauge
-sora_exporter_erlang_vm_runtime_total_run_time 200
-# HELP sora_exporter_erlang_vm_total_active_tasks The number of active processes and ports on each run queue and its associated schedulers. (only tasks that are expected to be CPU bound are part of the result.)
-# TYPE sora_exporter_erlang_vm_total_active_tasks gauge
-sora_exporter_erlang_vm_total_active_tasks 1
-# HELP sora_exporter_erlang_vm_total_active_tasks_all The number of active processes and ports on each run queue and its associated schedulers.
-# TYPE sora_exporter_erlang_vm_total_active_tasks_all gauge
-sora_exporter_erlang_vm_total_active_tasks_all 1
-# HELP sora_exporter_erlang_vm_total_run_queue_lengths The number of processes and ports ready to run for each run queue. (only run queues with work that is expected to be CPU bound is part of the result.)
-# TYPE sora_exporter_erlang_vm_total_run_queue_lengths gauge
-sora_exporter_erlang_vm_total_run_queue_lengths 0
-# HELP sora_exporter_erlang_vm_total_run_queue_lengths_all The number of processes and ports ready to run for each run queue.
-# TYPE sora_exporter_erlang_vm_total_run_queue_lengths_all gauge
-sora_exporter_erlang_vm_total_run_queue_lengths_all 0
-# HELP sora_exporter_erlang_vm_wall_clock_total_wallclock_time The number of information about wall clock.
-# TYPE sora_exporter_erlang_vm_wall_clock_total_wallclock_time gauge
-sora_exporter_erlang_vm_wall_clock_total_wallclock_time 994
-# HELP sora_exporter_erlang_vm_wall_clock_wallclock_time_since_last_call The number of information about wall clock since last call.
-# TYPE sora_exporter_erlang_vm_wall_clock_wallclock_time_since_last_call gauge
-sora_exporter_erlang_vm_wall_clock_wallclock_time_since_last_call 9090
-# HELP sora_exporter_failed_connections_total The total number of failed connections.
-# TYPE sora_exporter_failed_connections_total counter
-sora_exporter_failed_connections_total 0
-# HELP sora_exporter_ongoing_connections_total The total number of ongoing connections.
-# TYPE sora_exporter_ongoing_connections_total gauge
-sora_exporter_ongoing_connections_total 0
-# HELP sora_exporter_sora_version_info sora version info.
-# TYPE sora_exporter_sora_version_info gauge
-sora_exporter_sora_version_info{version="2022.1.0-canary.28"} 1
-# HELP sora_exporter_successfull_connections_total The total number of successfull connections.
-# TYPE sora_exporter_successfull_connections_total counter
-sora_exporter_successfull_connections_total 2
-# HELP sora_exporter_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
-# TYPE sora_exporter_total_received_invalid_turn_tcp_packet counter
-sora_exporter_total_received_invalid_turn_tcp_packet 0
-# HELP sora_exporter_total_session_created The total number of session created.
-# TYPE sora_exporter_total_session_created counter
-sora_exporter_total_session_created 1
-# HELP sora_exporter_total_session_destroyed The total number of session destroyed.
-# TYPE sora_exporter_total_session_destroyed counter
-sora_exporter_total_session_destroyed 0
-# HELP sora_exporter_turn_tcp_connections_total The total number of connections with TURN-TCP.
-# TYPE sora_exporter_turn_tcp_connections_total counter
-sora_exporter_turn_tcp_connections_total 2
-# HELP sora_exporter_turn_udp_connections_total The total number of connections with TURN-UDP.
-# TYPE sora_exporter_turn_udp_connections_total counter
-sora_exporter_turn_udp_connections_total 0
+# HELP sora_average_duration_seconds The average connection duration in seconds.
+# TYPE sora_average_duration_seconds gauge
+sora_average_duration_seconds 706
+# HELP sora_average_setup_time_seconds The average setup time in seconds.
+# TYPE sora_average_setup_time_seconds gauge
+sora_average_setup_time_seconds 0
+# HELP sora_connections_created_total The total number of connections created.
+# TYPE sora_connections_created_total counter
+sora_connections_created_total 2
+# HELP sora_connections_destroyed_total The total number of connections destryed.
+# TYPE sora_connections_destroyed_total counter
+sora_connections_destroyed_total 2
+# HELP sora_connections_updated_total The total number of connections updated.
+# TYPE sora_connections_updated_total counter
+sora_connections_updated_total 23
+# HELP sora_duration_seconds_total The total duration of connections.
+# TYPE sora_duration_seconds_total counter
+sora_duration_seconds_total 1412
+# HELP sora_erlang_vm_context_switches The total number of context switches since the system started.
+# TYPE sora_erlang_vm_context_switches counter
+sora_erlang_vm_context_switches 321
+# HELP sora_erlang_vm_exact_reductions_exact_reductions_since_last_call The number of exact reductions since last call.
+# TYPE sora_erlang_vm_exact_reductions_exact_reductions_since_last_call gauge
+sora_erlang_vm_exact_reductions_exact_reductions_since_last_call 213
+# HELP sora_erlang_vm_exact_reductions_total_exact_reductions The total number of exact reductions.
+# TYPE sora_erlang_vm_exact_reductions_total_exact_reductions counter
+sora_erlang_vm_exact_reductions_total_exact_reductions 432
+# HELP sora_erlang_vm_garbage_collection_number_of_gcs The number of information about garbage collection.
+# TYPE sora_erlang_vm_garbage_collection_number_of_gcs gauge
+sora_erlang_vm_garbage_collection_number_of_gcs 912
+# HELP sora_erlang_vm_garbage_collection_words_reclaimed The number of information about garbage collection word reclaimed.
+# TYPE sora_erlang_vm_garbage_collection_words_reclaimed gauge
+sora_erlang_vm_garbage_collection_words_reclaimed 345
+# HELP sora_erlang_vm_io_input The total number of bytes received through ports.
+# TYPE sora_erlang_vm_io_input counter
+sora_erlang_vm_io_input 769
+# HELP sora_erlang_vm_io_output The total number of bytes output through ports.
+# TYPE sora_erlang_vm_io_output counter
+sora_erlang_vm_io_output 331
+# HELP sora_erlang_vm_memory_atom The total amount of memory currently allocated for atoms. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_atom gauge
+sora_erlang_vm_memory_atom 3333
+# HELP sora_erlang_vm_memory_atom_used The total amount of memory currently used for atoms. This memory is part of the memory presented as atom memory.
+# TYPE sora_erlang_vm_memory_atom_used gauge
+sora_erlang_vm_memory_atom_used 2222
+# HELP sora_erlang_vm_memory_binary The total amount of memory currently allocated for binaries. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_binary gauge
+sora_erlang_vm_memory_binary 1111
+# HELP sora_erlang_vm_memory_code The total amount of memory currently allocated for Erlang code. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_code gauge
+sora_erlang_vm_memory_code 777
+# HELP sora_erlang_vm_memory_ets The total amount of memory currently allocated for ETS tables. This memory is part of the memory presented as system memory.
+# TYPE sora_erlang_vm_memory_ets gauge
+sora_erlang_vm_memory_ets 888
+# HELP sora_erlang_vm_memory_processes The total amount of memory currently allocated for the Erlang processes.
+# TYPE sora_erlang_vm_memory_processes gauge
+sora_erlang_vm_memory_processes 5678
+# HELP sora_erlang_vm_memory_processes_used The total amount of memory currently used by the Erlang processes. This is part of the memory presented as processes memory.
+# TYPE sora_erlang_vm_memory_processes_used gauge
+sora_erlang_vm_memory_processes_used 6666
+# HELP sora_erlang_vm_memory_system The total amount of memory currently allocated for the emulator that is not directly related to any Erlang process. Memory presented as processes is not included in this memory. instrument(3) can be used to get a more detailed breakdown of what memory is part of this type.
+# TYPE sora_erlang_vm_memory_system gauge
+sora_erlang_vm_memory_system 4444
+# HELP sora_erlang_vm_memory_total The total amount of memory currently allocated. This is the same as the sum of the memory size for processes and system.
+# TYPE sora_erlang_vm_memory_total gauge
+sora_erlang_vm_memory_total 1234
+# HELP sora_erlang_vm_reductions_reductions_since_last_call The number of information about reductions.
+# TYPE sora_erlang_vm_reductions_reductions_since_last_call gauge
+sora_erlang_vm_reductions_reductions_since_last_call 443
+# HELP sora_erlang_vm_reductions_total_reductions The total number of information about reductions.
+# TYPE sora_erlang_vm_reductions_total_reductions counter
+sora_erlang_vm_reductions_total_reductions 8080
+# HELP sora_erlang_vm_run_queue The total length of all normal and dirty CPU run queues.
+# TYPE sora_erlang_vm_run_queue gauge
+sora_erlang_vm_run_queue 0
+# HELP sora_erlang_vm_runtime_time_since_last_call The number of information about runtime since last call, in milliseconds.
+# TYPE sora_erlang_vm_runtime_time_since_last_call gauge
+sora_erlang_vm_runtime_time_since_last_call 100
+# HELP sora_erlang_vm_runtime_total_run_time The number of information about runtime, in milliseconds.
+# TYPE sora_erlang_vm_runtime_total_run_time gauge
+sora_erlang_vm_runtime_total_run_time 200
+# HELP sora_erlang_vm_total_active_tasks The number of active processes and ports on each run queue and its associated schedulers. (only tasks that are expected to be CPU bound are part of the result.)
+# TYPE sora_erlang_vm_total_active_tasks gauge
+sora_erlang_vm_total_active_tasks 1
+# HELP sora_erlang_vm_total_active_tasks_all The number of active processes and ports on each run queue and its associated schedulers.
+# TYPE sora_erlang_vm_total_active_tasks_all gauge
+sora_erlang_vm_total_active_tasks_all 1
+# HELP sora_erlang_vm_total_run_queue_lengths The number of processes and ports ready to run for each run queue. (only run queues with work that is expected to be CPU bound is part of the result.)
+# TYPE sora_erlang_vm_total_run_queue_lengths gauge
+sora_erlang_vm_total_run_queue_lengths 0
+# HELP sora_erlang_vm_total_run_queue_lengths_all The number of processes and ports ready to run for each run queue.
+# TYPE sora_erlang_vm_total_run_queue_lengths_all gauge
+sora_erlang_vm_total_run_queue_lengths_all 0
+# HELP sora_erlang_vm_wall_clock_total_wallclock_time The number of information about wall clock.
+# TYPE sora_erlang_vm_wall_clock_total_wallclock_time gauge
+sora_erlang_vm_wall_clock_total_wallclock_time 994
+# HELP sora_erlang_vm_wall_clock_wallclock_time_since_last_call The number of information about wall clock since last call.
+# TYPE sora_erlang_vm_wall_clock_wallclock_time_since_last_call gauge
+sora_erlang_vm_wall_clock_wallclock_time_since_last_call 9090
+# HELP sora_failed_connections_total The total number of failed connections.
+# TYPE sora_failed_connections_total counter
+sora_failed_connections_total 0
+# HELP sora_ongoing_connections_total The total number of ongoing connections.
+# TYPE sora_ongoing_connections_total gauge
+sora_ongoing_connections_total 0
+# HELP sora_sora_version_info sora version info.
+# TYPE sora_sora_version_info gauge
+sora_sora_version_info{version="2022.1.0-canary.28"} 1
+# HELP sora_successfull_connections_total The total number of successfull connections.
+# TYPE sora_successfull_connections_total counter
+sora_successfull_connections_total 2
+# HELP sora_total_received_invalid_turn_tcp_packet The total number of invalid packets with TURN-TCP
+# TYPE sora_total_received_invalid_turn_tcp_packet counter
+sora_total_received_invalid_turn_tcp_packet 0
+# HELP sora_total_session_created The total number of session created.
+# TYPE sora_total_session_created counter
+sora_total_session_created 1
+# HELP sora_total_session_destroyed The total number of session destroyed.
+# TYPE sora_total_session_destroyed counter
+sora_total_session_destroyed 0
+# HELP sora_turn_tcp_connections_total The total number of connections with TURN-TCP.
+# TYPE sora_turn_tcp_connections_total counter
+sora_turn_tcp_connections_total 2
+# HELP sora_turn_udp_connections_total The total number of connections with TURN-UDP.
+# TYPE sora_turn_udp_connections_total counter
+sora_turn_udp_connections_total 0


### PR DESCRIPTION
大きくは以下の内容の修正です。
メトリクスの出力結果は、テスト用の .metrics ファイルの diff をみていただくと分かりやすいです。

* メトリクスの接頭辞 `sora_exporter` を `sora` に変更しました
* `sora_up` メトリクス追加しました
* 接続数、接続クライアント、エラーなどをメトリクス名は共通にし、インストルメンテーションラベルに状態やクライアント名を設定するように変更しました
* Discord にて指摘をもらっていた `_total` を末尾に移し、 OpenMetrics の命名規則に従うようにしました
    * Erlang VM のメトリクスに関しては、現時点では逆に分かりにくくなると思ったので修正を見送っています
