### PR TITLE
Sora クラスターの監視用メトリクスを追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
     - @tnamao
 - [ADD] Sora への接続可否を判定するための `sora_up` メトリクスを追加する
     - @tnamao
+- [ADD] Sora が認識しているクラスターノードをメトリクスで返す `sora_cluster_node` を追加する
+    - @tnamao
 - [CHANGE] GitHub リリースのタイトルにタグ名を設定する
     - @tnamao
 - [CHANGE] リリース時のアーカイブファイルに対象の OS 名を含める

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -1,0 +1,27 @@
+package collector
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	soraClusterMetrics = SoraClusterMetrics{
+		clusterNode: newDescWithLabel("cluster_node", "The sora server known cluster node.", []string{"node_name", "mode"}),
+	}
+)
+
+type SoraClusterMetrics struct {
+	clusterNode *prometheus.Desc
+}
+
+func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.clusterNode
+}
+
+func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []soraClusterNode) {
+	for _, node := range nodeList {
+		if node.ClusterNodeName != nil {
+			ch <- newGauge(m.clusterNode, 1, *node.ClusterNodeName, *node.Mode)
+		} else {
+			ch <- newGauge(m.clusterNode, 1, *node.NodeName, *node.Mode)
+		}
+	}
+}

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -109,3 +109,9 @@ type erlangVmReport struct {
 	ErlangVmMemory     erlangVmMemory     `json:"memory"`
 	ErlangVmStatistics erlangVmStatistics `json:"statistics"`
 }
+
+type soraClusterNode struct {
+	ClusterNodeName *string `json:"cluster_node_name"`
+	NodeName        *string `json:"node_name"`
+	Mode            *string `json:"mode"`
+}

--- a/main_test.go
+++ b/main_test.go
@@ -123,21 +123,56 @@ var (
 		"total_turn_udp_connections": 0,
 		"version": "2022.1.0-canary.28"
 	  }`
+	listClusterNodesJsonData = `[
+		{
+		  "node_name": "node-01_canary_sora@10.211.55.42",
+		  "epoch": 1,
+		  "mode": "normal",
+		  "cluster_signaling_url": "ws://127.0.0.1:5001/signaling",
+		  "cluster_api_url": "http://127.0.0.1:3101/",
+		  "member_since": "2022-05-09T07:44:52.973761Z",
+		  "sora_version": "2022.1.0-canary.44",
+		  "license_max_nodes": 10,
+		  "license_max_connections": 100,
+		  "license_serial_code": "TNAMAO-SRA-E003-202212-N10-100",
+		  "license_type": "Experimental",
+		  "connected": true
+		},
+		{
+		  "node_name": "node-02_canary_sora@10.211.55.40",
+		  "epoch": 1,
+		  "mode": "block_new_connection",
+		  "cluster_signaling_url": "ws://127.0.0.1:5002/signaling",
+		  "cluster_api_url": "http://127.0.0.1:3102/",
+		  "member_since": "2022-05-09T07:44:54.160763Z",
+		  "sora_version": "2022.1.0-canary.44",
+		  "license_max_nodes": 10,
+		  "license_max_connections": 100,
+		  "license_serial_code": "TNAMAO-SRA-E003-202212-N10-100",
+		  "license_type": "Experimental",
+		  "connected": true
+		}
+	  ]`
 )
 
 type sora struct {
 	*httptest.Server
-	response []byte
+	response                 []byte
+	listClusterNodesResponse []byte
 }
 
-func newSora(response []byte) *sora {
-	s := &sora{response: response}
+func newSora(response []byte, listClusterNodesResponse []byte) *sora {
+	s := &sora{response: response, listClusterNodesResponse: listClusterNodesResponse}
 	s.Server = httptest.NewServer(soraHandler(s))
 	return s
 }
 
 func soraHandler(s *sora) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-sora-target") == "Sora_20211215.ListClusterNodes" {
+			w.Write(s.listClusterNodesResponse)
+			return
+		}
 		w.Write(s.response)
 	}
 }
@@ -159,7 +194,7 @@ func expectMetrics(t *testing.T, c prometheus.Collector, fixture string) {
 }
 
 func TestInvalidConfig(t *testing.T) {
-	s := newSora([]byte("invalid config parameter"))
+	s := newSora([]byte("invalid config parameter"), []byte(listClusterNodesJsonData))
 	defer s.Close()
 
 	timeout, _ := time.ParseDuration("5s")
@@ -171,12 +206,13 @@ func TestInvalidConfig(t *testing.T) {
 		EnableSoraClientMetrics:          true,
 		EnableSoraConnectionErrorMetrics: true,
 		EnableErlangVmMetrics:            true,
+		EnableSoraClusterMetrics:         true,
 	})
 	expectMetrics(t, h, "invalid_config.metrics")
 }
 
 func TestMaximumMetrics(t *testing.T) {
-	s := newSora([]byte(testJsonData))
+	s := newSora([]byte(testJsonData), []byte(listClusterNodesJsonData))
 	defer s.Close()
 
 	timeout, _ := time.ParseDuration("5s")
@@ -188,12 +224,13 @@ func TestMaximumMetrics(t *testing.T) {
 		EnableSoraClientMetrics:          true,
 		EnableSoraConnectionErrorMetrics: true,
 		EnableErlangVmMetrics:            true,
+		EnableSoraClusterMetrics:         true,
 	})
 	expectMetrics(t, h, "maximum.metrics")
 }
 
 func TestSoraErlangVmEnabledMetrics(t *testing.T) {
-	s := newSora([]byte(testJsonData))
+	s := newSora([]byte(testJsonData), []byte(listClusterNodesJsonData))
 	defer s.Close()
 
 	timeout, _ := time.ParseDuration("5s")
@@ -205,12 +242,13 @@ func TestSoraErlangVmEnabledMetrics(t *testing.T) {
 		EnableSoraClientMetrics:          false,
 		EnableSoraConnectionErrorMetrics: false,
 		EnableErlangVmMetrics:            true,
+		EnableSoraClusterMetrics:         false,
 	})
 	expectMetrics(t, h, "sora_erlang_vm_enabled.metrics")
 }
 
 func TestSoraClientEnabledMetrics(t *testing.T) {
-	s := newSora([]byte(testJsonData))
+	s := newSora([]byte(testJsonData), []byte(listClusterNodesJsonData))
 	defer s.Close()
 
 	timeout, _ := time.ParseDuration("5s")
@@ -222,12 +260,13 @@ func TestSoraClientEnabledMetrics(t *testing.T) {
 		EnableSoraClientMetrics:          true,
 		EnableSoraConnectionErrorMetrics: false,
 		EnableErlangVmMetrics:            false,
+		EnableSoraClusterMetrics:         false,
 	})
 	expectMetrics(t, h, "sora_client_enabled.metrics")
 }
 
 func TestSoraConnectionErrorEnabledMetrics(t *testing.T) {
-	s := newSora([]byte(testJsonData))
+	s := newSora([]byte(testJsonData), []byte(listClusterNodesJsonData))
 	defer s.Close()
 
 	timeout, _ := time.ParseDuration("5s")
@@ -239,6 +278,7 @@ func TestSoraConnectionErrorEnabledMetrics(t *testing.T) {
 		EnableSoraClientMetrics:          false,
 		EnableSoraConnectionErrorMetrics: true,
 		EnableErlangVmMetrics:            false,
+		EnableSoraClusterMetrics:         false,
 	})
 	expectMetrics(t, h, "sora_connection_error_enabled.metrics")
 }
@@ -261,7 +301,7 @@ func TestMinimumMetrics(t *testing.T) {
 		"total_turn_udp_connections": 555,
 		"version": "2022.1.0-canary.28"
 	  }`
-	s := newSora([]byte(resp))
+	s := newSora([]byte(resp), []byte(listClusterNodesJsonData))
 	defer s.Close()
 
 	timeout, _ := time.ParseDuration("5s")
@@ -273,6 +313,25 @@ func TestMinimumMetrics(t *testing.T) {
 		EnableSoraClientMetrics:          false,
 		EnableSoraConnectionErrorMetrics: false,
 		EnableErlangVmMetrics:            false,
+		EnableSoraClusterMetrics:         false,
 	})
 	expectMetrics(t, h, "minimum.metrics")
+}
+
+func TestSoraClusterEnabledMetrics(t *testing.T) {
+	s := newSora([]byte(testJsonData), []byte(listClusterNodesJsonData))
+	defer s.Close()
+
+	timeout, _ := time.ParseDuration("5s")
+	h := collector.NewCollector(&collector.CollectorOptions{
+		URI:                              s.URL,
+		SkipSslVerify:                    true,
+		Timeout:                          timeout,
+		Logger:                           log.NewNopLogger(),
+		EnableSoraClientMetrics:          false,
+		EnableSoraConnectionErrorMetrics: false,
+		EnableErlangVmMetrics:            false,
+		EnableSoraClusterMetrics:         true,
+	})
+	expectMetrics(t, h, "sora_cluster_metrics_enabled.metrics")
 }

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -4,6 +4,10 @@ sora_average_duration_seconds 706
 # HELP sora_average_setup_time_seconds The average setup time in seconds.
 # TYPE sora_average_setup_time_seconds gauge
 sora_average_setup_time_seconds 0
+# HELP sora_cluster_node The sora server known cluster node.
+# TYPE sora_cluster_node gauge
+sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40"} 1
+sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
 # HELP sora_client_type_total The total number of connections by Sora client types
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -1,0 +1,40 @@
+# HELP sora_average_duration_seconds The average connection duration in seconds.
+# TYPE sora_average_duration_seconds gauge
+sora_average_duration_seconds 706
+# HELP sora_average_setup_time_seconds The average setup time in seconds.
+# TYPE sora_average_setup_time_seconds gauge
+sora_average_setup_time_seconds 0
+# HELP sora_cluster_node The sora server known cluster node.
+# TYPE sora_cluster_node gauge
+sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40"} 1
+sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
+# HELP sora_connections_total The total number of connections created.
+# TYPE sora_connections_total counter
+sora_connections_total{state="created"} 2
+sora_connections_total{state="destroyed"} 2
+sora_connections_total{state="failed"} 0
+sora_connections_total{state="successful"} 2
+sora_connections_total{state="updated"} 23
+# HELP sora_duration_seconds_total The total duration of connections.
+# TYPE sora_duration_seconds_total counter
+sora_duration_seconds_total 1412
+# HELP sora_ongoing_connections_total The total number of ongoing connections.
+# TYPE sora_ongoing_connections_total gauge
+sora_ongoing_connections_total 0
+# HELP sora_received_invalid_turn_tcp_packet_total The total number of invalid packets with TURN-TCP
+# TYPE sora_received_invalid_turn_tcp_packet_total counter
+sora_received_invalid_turn_tcp_packet_total 0
+# HELP sora_session_total The total number of session.
+# TYPE sora_session_total counter
+sora_session_total{state="created"} 1
+sora_session_total{state="destroyed"} 0
+# HELP sora_turn_connections_total The total number of connections with TURN.
+# TYPE sora_turn_connections_total counter
+sora_turn_connections_total{proto="tcp"} 2
+sora_turn_connections_total{proto="udp"} 0
+# HELP sora_up Whether the last scrape of metrics from Sora was able to connect to the server (1 for yes, 0 for no).
+# TYPE sora_up gauge
+sora_up 1
+# HELP sora_version_info sora version info.
+# TYPE sora_version_info gauge
+sora_version_info{version="2022.1.0-canary.28"} 1


### PR DESCRIPTION
新たに `sora_cluster_node` というメトリクスを追加しました。
認識しているクラスター内のノード名とモードをラベルに入れて返します。

```
# HELP sora_cluster_node The sora server known cluster node.
# TYPE sora_cluster_node gauge
sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40"} 1
sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
```