### PR TITLE
Sora のクラスタ機能で使用している Raft 関連のメトリクスを追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # CHANGES
 
+## develop
+
+- [ADD] クラスタ機能で使用している Raft 関連のメトリクスを追加
+  - 以下の三つのメトリクスを追加する
+    - [counter] sora_cluster_raft_commit_index ${INDEX}
+    - [counter] sora_cluster_raft_term ${TERM}
+    - [gauge] sora_cluster_raft_role { role = "${ROLE_NAME}" } 1
+  - これらは、以下の条件が満たされた時だけ、結果に含まれる
+    - Sora のクラスタ機能が有効になっている
+    - sora_exporter が `--sora.cluster-metrics` オプション付きで起動されている
+  - @sile
+
 ## 2022.5.0
 
 - [ADD] Sora の接続クライアントメトリクスに `flutter_sdk` を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   - 以下の三つのメトリクスを追加する
     - [counter] sora_cluster_raft_commit_index ${INDEX}
     - [counter] sora_cluster_raft_term ${TERM}
-    - [gauge] sora_cluster_raft_role { role = "${ROLE_NAME}" } 1
+    - [gauge] sora_cluster_raft_state { state = "${STATE_NAME}" } 1
   - これらは、以下の条件が満たされた時だけ、結果に含まれる
     - Sora のクラスタ機能が有効になっている
     - sora_exporter が `--sora.cluster-metrics` オプション付きで起動されている

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -33,11 +33,7 @@ func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []sor
 			ch <- newGauge(m.clusterNode, 1, *node.NodeName, *node.Mode)
 		}
 	}
-	if report.RaftState == "" {
-		ch <- newGauge(m.raftState, 1.0, "undefined")
-	} else {
-		ch <- newGauge(m.raftState, 1.0, report.RaftState)
-	}
+	ch <- newGauge(m.raftState, 1.0, report.RaftState)
 	ch <- newCounter(m.raftTerm, float64(report.RaftTerm))
 	ch <- newCounter(m.raftCommitIndex, float64(report.RaftCommitIndex))
 }

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -6,7 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	soraClusterMetrics = SoraClusterMetrics{
 		clusterNode: newDescWithLabel("cluster_node", "The sora server known cluster node.", []string{"node_name", "mode"}),
-		raftRole:        newDescWithLabel("cluster_raft_role", "The current Raft role (follower or leader). The role name is indicated by the label 'role'. The value of this metric is always set to 1.", []string{"role"}),
+		raftRole:        newDescWithLabel("cluster_raft_role", "The current Raft role. The role name is indicated by the label 'role'. The value of this metric is always set to 1.", []string{"role"}),
 		raftTerm:        newDesc("cluster_raft_term", "The current Raft term."),
 		raftCommitIndex: newDesc("cluster_raft_commit_index", "The latest committed Raft log index."),
 	}

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -1,3 +1,4 @@
+// TODO: rename file
 package collector
 
 import "github.com/prometheus/client_golang/prometheus"
@@ -5,18 +6,27 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	soraClusterMetrics = SoraClusterMetrics{
 		clusterNode: newDescWithLabel("cluster_node", "The sora server known cluster node.", []string{"node_name", "mode"}),
+		raftRole:        newDescWithLabel("cluster_raft_role", "The current Raft role (follower or leader). The role name is indicated by the label 'role'. The value of this metric is always set to 1.", []string{"role"}),
+		raftTerm:        newDesc("cluster_raft_term", "The current Raft term."),
+		raftCommitIndex: newDesc("cluster_raft_commit_index", "The latest committed Raft log index."),
 	}
 )
 
 type SoraClusterMetrics struct {
-	clusterNode *prometheus.Desc
+	clusterNode     *prometheus.Desc
+	raftRole        *prometheus.Desc
+	raftTerm        *prometheus.Desc
+	raftCommitIndex *prometheus.Desc
 }
 
 func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.clusterNode
+	ch <- m.raftRole
+	ch <- m.raftTerm
+	ch <- m.raftCommitIndex
 }
 
-func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []soraClusterNode) {
+func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []soraClusterNode, report soraClusterReport) {
 	for _, node := range nodeList {
 		if node.ClusterNodeName != nil {
 			ch <- newGauge(m.clusterNode, 1, *node.ClusterNodeName, *node.Mode)
@@ -24,4 +34,7 @@ func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []sor
 			ch <- newGauge(m.clusterNode, 1, *node.NodeName, *node.Mode)
 		}
 	}
+	ch <- newGauge(m.raftRole, 1.0, report.RaftRole)
+	ch <- newCounter(m.raftTerm, float64(report.RaftTerm))
+	ch <- newCounter(m.raftCommitIndex, float64(report.RaftCommitIndex))
 }

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -6,7 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	soraClusterMetrics = SoraClusterMetrics{
 		clusterNode: newDescWithLabel("cluster_node", "The sora server known cluster node.", []string{"node_name", "mode"}),
-		raftRole:        newDescWithLabel("cluster_raft_role", "The current Raft role. The role name is indicated by the label 'role'. The value of this metric is always set to 1.", []string{"role"}),
+		raftState:        newDescWithLabel("cluster_raft_state", "The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.", []string{"state"}),
 		raftTerm:        newDesc("cluster_raft_term", "The current Raft term."),
 		raftCommitIndex: newDesc("cluster_raft_commit_index", "The latest committed Raft log index."),
 	}
@@ -14,14 +14,14 @@ var (
 
 type SoraClusterMetrics struct {
 	clusterNode     *prometheus.Desc
-	raftRole        *prometheus.Desc
+	raftState        *prometheus.Desc
 	raftTerm        *prometheus.Desc
 	raftCommitIndex *prometheus.Desc
 }
 
 func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.clusterNode
-	ch <- m.raftRole
+	ch <- m.raftState
 	ch <- m.raftTerm
 	ch <- m.raftCommitIndex
 }
@@ -34,7 +34,7 @@ func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []sor
 			ch <- newGauge(m.clusterNode, 1, *node.NodeName, *node.Mode)
 		}
 	}
-	ch <- newGauge(m.raftRole, 1.0, report.RaftRole)
+	ch <- newGauge(m.raftState, 1.0, report.RaftState)
 	ch <- newCounter(m.raftTerm, float64(report.RaftTerm))
 	ch <- newCounter(m.raftCommitIndex, float64(report.RaftCommitIndex))
 }

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -1,4 +1,3 @@
-// TODO: rename file
 package collector
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -4,8 +4,8 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	soraClusterMetrics = SoraClusterMetrics{
-		clusterNode: newDescWithLabel("cluster_node", "The sora server known cluster node.", []string{"node_name", "mode"}),
-		raftState:        newDescWithLabel("cluster_raft_state", "The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.", []string{"state"}),
+		clusterNode:     newDescWithLabel("cluster_node", "The sora server known cluster node.", []string{"node_name", "mode"}),
+		raftState:       newDescWithLabel("cluster_raft_state", "The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.", []string{"state"}),
 		raftTerm:        newDesc("cluster_raft_term", "The current Raft term."),
 		raftCommitIndex: newDesc("cluster_raft_commit_index", "The latest committed Raft log index."),
 	}
@@ -13,7 +13,7 @@ var (
 
 type SoraClusterMetrics struct {
 	clusterNode     *prometheus.Desc
-	raftState        *prometheus.Desc
+	raftState       *prometheus.Desc
 	raftTerm        *prometheus.Desc
 	raftCommitIndex *prometheus.Desc
 }

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -33,7 +33,11 @@ func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []sor
 			ch <- newGauge(m.clusterNode, 1, *node.NodeName, *node.Mode)
 		}
 	}
-	ch <- newGauge(m.raftState, 1.0, report.RaftState)
+	if report.RaftState == "" {
+		ch <- newGauge(m.raftState, 1.0, "undefined")
+	} else {
+		ch <- newGauge(m.raftState, 1.0, report.RaftState)
+	}
 	ch <- newCounter(m.raftTerm, float64(report.RaftTerm))
 	ch <- newCounter(m.raftCommitIndex, float64(report.RaftCommitIndex))
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -148,7 +148,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		c.ErlangVMMetrics.Collect(ch, report.ErlangVMReport)
 	}
 	if c.EnableSoraClusterMetrics {
-		c.SoraClusterMetrics.Collect(ch, nodeList)
+		c.SoraClusterMetrics.Collect(ch, nodeList, report.ClusterReport)
 	}
 }
 

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -127,9 +127,9 @@ type erlangVMReport struct {
 }
 
 type soraClusterReport struct {
-	RaftState string       `json:"raft_state"`
-	RaftTerm int64        `json:"raft_term"`
-	RaftCommitIndex int64 `json:"raft_commit_index"`
+	RaftState       string `json:"raft_state"`
+	RaftTerm        int64  `json:"raft_term"`
+	RaftCommitIndex int64  `json:"raft_commit_index"`
 }
 
 type soraClusterNode struct {

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -7,6 +7,7 @@ type soraGetStatsReport struct {
 	SoraClientReport          soraClientReport          `json:"sora_client,omitempty"`
 	SoraConnectionErrorReport soraConnectionErrorReport `json:"error,omitempty"`
 	ErlangVMReport            erlangVMReport            `json:"erlang_vm,omitempty"`
+	ClusterReport             soraClusterReport         `json:"cluster,omitempty"`
 }
 
 type soraConnectionReport struct {
@@ -123,6 +124,12 @@ type erlangVMStatistics struct {
 type erlangVMReport struct {
 	ErlangVMMemory     erlangVMMemory     `json:"memory"`
 	ErlangVMStatistics erlangVMStatistics `json:"statistics"`
+}
+
+type soraClusterReport struct {
+	RaftRole string       `json:"raft_role"`
+	RaftTerm int64        `json:"raft_term"`
+	RaftCommitIndex int64 `json:"raft_commit_index"`
 }
 
 type soraClusterNode struct {

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -127,7 +127,7 @@ type erlangVMReport struct {
 }
 
 type soraClusterReport struct {
-	RaftRole string       `json:"raft_role"`
+	RaftState string       `json:"raft_state"`
 	RaftTerm int64        `json:"raft_term"`
 	RaftCommitIndex int64 `json:"raft_commit_index"`
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,11 @@ var (
 	testJSONData = `{
 		"average_duration_sec": 706,
 		"average_setup_time_msec": 372,
+                "cluster": {
+                  "raft_commit_index": 10,
+                  "raft_state": "follower",
+                  "raft_term": 3
+                },
 		"erlang_vm": {
 		  "memory": {
 			"total": 1234,

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -12,6 +12,15 @@ sora_average_setup_time_seconds 0
 # TYPE sora_cluster_node gauge
 sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40"} 1
 sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
+# HELP sora_cluster_raft_commit_index The latest committed Raft log index.
+# TYPE sora_cluster_raft_commit_index counter
+sora_cluster_raft_commit_index 0
+# HELP sora_cluster_raft_role The current Raft role. The role name is indicated by the label 'role'. The value of this metric is always set to 1.
+# TYPE sora_cluster_raft_role gauge
+sora_cluster_raft_role{role=""} 1
+# HELP sora_cluster_raft_term The current Raft term.
+# TYPE sora_cluster_raft_term counter
+sora_cluster_raft_term 0
 # HELP sora_client_type_total The total number of connections by Sora client types
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -14,13 +14,13 @@ sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.
 sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
 # HELP sora_cluster_raft_commit_index The latest committed Raft log index.
 # TYPE sora_cluster_raft_commit_index counter
-sora_cluster_raft_commit_index 0
+sora_cluster_raft_commit_index 10
 # HELP sora_cluster_raft_state The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.
 # TYPE sora_cluster_raft_state gauge
-sora_cluster_raft_state{state=""} 1
+sora_cluster_raft_state{state="follower"} 1
 # HELP sora_cluster_raft_term The current Raft term.
 # TYPE sora_cluster_raft_term counter
-sora_cluster_raft_term 0
+sora_cluster_raft_term 3
 # HELP sora_client_type_total The total number of connections by Sora client types
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -15,9 +15,9 @@ sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
 # HELP sora_cluster_raft_commit_index The latest committed Raft log index.
 # TYPE sora_cluster_raft_commit_index counter
 sora_cluster_raft_commit_index 0
-# HELP sora_cluster_raft_role The current Raft role. The role name is indicated by the label 'role'. The value of this metric is always set to 1.
-# TYPE sora_cluster_raft_role gauge
-sora_cluster_raft_role{role=""} 1
+# HELP sora_cluster_raft_state The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.
+# TYPE sora_cluster_raft_state gauge
+sora_cluster_raft_state{state=""} 1
 # HELP sora_cluster_raft_term The current Raft term.
 # TYPE sora_cluster_raft_term counter
 sora_cluster_raft_term 0

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -12,6 +12,15 @@ sora_average_setup_time_seconds 0
 # TYPE sora_cluster_node gauge
 sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40"} 1
 sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
+# HELP sora_cluster_raft_commit_index The latest committed Raft log index.
+# TYPE sora_cluster_raft_commit_index counter
+sora_cluster_raft_commit_index 0
+# HELP sora_cluster_raft_role The current Raft role. The role name is indicated by the label 'role'. The value of this metric is always set to 1.
+# TYPE sora_cluster_raft_role gauge
+sora_cluster_raft_role{role=""} 1
+# HELP sora_cluster_raft_term The current Raft term.
+# TYPE sora_cluster_raft_term counter
+sora_cluster_raft_term 0
 # HELP sora_connections_total The total number of connections created.
 # TYPE sora_connections_total counter
 sora_connections_total{state="created"} 2

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -14,13 +14,13 @@ sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.
 sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
 # HELP sora_cluster_raft_commit_index The latest committed Raft log index.
 # TYPE sora_cluster_raft_commit_index counter
-sora_cluster_raft_commit_index 0
+sora_cluster_raft_commit_index 10
 # HELP sora_cluster_raft_state The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.
 # TYPE sora_cluster_raft_state gauge
-sora_cluster_raft_state{state=""} 1
+sora_cluster_raft_state{state="follower"} 1
 # HELP sora_cluster_raft_term The current Raft term.
 # TYPE sora_cluster_raft_term counter
-sora_cluster_raft_term 0
+sora_cluster_raft_term 3
 # HELP sora_connections_total The total number of connections created.
 # TYPE sora_connections_total counter
 sora_connections_total{state="created"} 2

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -15,9 +15,9 @@ sora_cluster_node{mode="normal",node_name="node-01_canary_sora@10.211.55.42"} 1
 # HELP sora_cluster_raft_commit_index The latest committed Raft log index.
 # TYPE sora_cluster_raft_commit_index counter
 sora_cluster_raft_commit_index 0
-# HELP sora_cluster_raft_role The current Raft role. The role name is indicated by the label 'role'. The value of this metric is always set to 1.
-# TYPE sora_cluster_raft_role gauge
-sora_cluster_raft_role{role=""} 1
+# HELP sora_cluster_raft_state The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.
+# TYPE sora_cluster_raft_state gauge
+sora_cluster_raft_state{state=""} 1
 # HELP sora_cluster_raft_term The current Raft term.
 # TYPE sora_cluster_raft_term counter
 sora_cluster_raft_term 0


### PR DESCRIPTION
Sora (canary) の GetStatsReport API の項目追加に追従しました。

- [ADD] クラスタ機能で使用している Raft 関連のメトリクスを追加
  - 以下の三つのメトリクスを追加する
    - [counter] sora_cluster_raft_commit_index ${INDEX}
    - [counter] sora_cluster_raft_term ${TERM}
    - [gauge] sora_cluster_raft_state { state = "${STATE_NAME}" } 1
  - これらは、以下の条件が満たされた時だけ、結果に含まれる
    - Sora のクラスタ機能が有効になっている
    - sora_exporter が `--sora.cluster-metrics` オプション付きで起動されている