### PR TITLE
クライアント統計の sora-c-sdk 対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # CHANGES
 
+## develop
+
+- [ADD] `sora_client` の `sora_c_sdk` に対応する
+  - @tnamao
+
 ## 2023.4.0
 
 - [ADD] `sora_client` の `sora_python_sdk` に対応する

--- a/collector/client.go
+++ b/collector/client.go
@@ -19,6 +19,7 @@ func (m *ClientMetrics) Describe(ch chan<- *prometheus.Desc) {
 
 func (m *ClientMetrics) Collect(ch chan<- prometheus.Metric, report soraClientReport) {
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraAndroidSdk), "android_sdk", "failed")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraCSdk), "c_sdk", "failed")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraCppSdk), "cpp_sdk", "failed")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraFlutterSdk), "flutter_sdk", "failed")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.SoraIosSdk), "ios_sdk", "failed")
@@ -30,6 +31,7 @@ func (m *ClientMetrics) Collect(ch chan<- prometheus.Metric, report soraClientRe
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.WebrtcLoadTestingToolZakuro), "zakuro", "failed")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalFailedSoraClientType.WebrtcNativeClientMomo), "momo", "failed")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraAndroidSdk), "android_sdk", "successful")
+	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraCSdk), "c_sdk", "successful")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraCppSdk), "cpp_sdk", "successful")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraFlutterSdk), "flutter_sdk", "successful")
 	ch <- newCounter(m.totalSoraClientConnections, float64(report.TotalSuccessfulSoraClientType.SoraIosSdk), "ios_sdk", "successful")

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -40,6 +40,7 @@ type soraWebhookReport struct {
 
 type soraClientStatistics struct {
 	SoraAndroidSdk              int64 `json:"sora_android_sdk"`
+	SoraCSdk                    int64 `json:"sora_c_sdk"`
 	SoraCppSdk                  int64 `json:"sora_cpp_sdk"`
 	SoraFlutterSdk              int64 `json:"sora_flutter_sdk"`
 	SoraIosSdk                  int64 `json:"sora_ios_sdk"`

--- a/main_test.go
+++ b/main_test.go
@@ -98,6 +98,7 @@ var (
 		"sora_client": {
 		  "total_failed_sora_client_type": {
 			"sora_android_sdk": 1,
+			"sora_c_sdk": 12,
 			"sora_cpp_sdk": 7,
 			"sora_flutter_sdk": 9,
 			"sora_ios_sdk": 2,
@@ -111,6 +112,7 @@ var (
 		  },
 		  "total_successful_sora_client_type": {
 			"sora_android_sdk": 11,
+			"sora_c_sdk": 1212,
 			"sora_cpp_sdk": 77,
 			"sora_flutter_sdk": 99,
 			"sora_ios_sdk": 22,

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -25,6 +25,8 @@ sora_cluster_raft_term 3
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1
 sora_client_type_total{client="android_sdk",state="successful"} 11
+sora_client_type_total{client="c_sdk",state="failed"} 12
+sora_client_type_total{client="c_sdk",state="successful"} 1212
 sora_client_type_total{client="cpp_sdk",state="failed"} 7
 sora_client_type_total{client="cpp_sdk",state="successful"} 77
 sora_client_type_total{client="flutter_sdk",state="failed"} 9

--- a/test/sora_client_enabled.metrics
+++ b/test/sora_client_enabled.metrics
@@ -12,6 +12,8 @@ sora_average_setup_time_seconds 0
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1
 sora_client_type_total{client="android_sdk",state="successful"} 11
+sora_client_type_total{client="c_sdk",state="failed"} 12
+sora_client_type_total{client="c_sdk",state="successful"} 1212
 sora_client_type_total{client="cpp_sdk",state="failed"} 7
 sora_client_type_total{client="cpp_sdk",state="successful"} 77
 sora_client_type_total{client="flutter_sdk",state="failed"} 9


### PR DESCRIPTION
### 変更履歴

- [ADD] `sora_client` の `sora_c_sdk` に対応する
  - @tnamao
