### PR TITLE
cluster_relay 統計情報への対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # CHANGES
 
+- [ADD] Sora のクラスターリレー機能のメトリクスを追加する
+  - GetStatsReport API の `cluster_relay` 以下の統計情報を、起動オプションの `--sora.cluster-metrics` を有効にした時のみ収集する
+  - 次のメトリクスを送受信しているノード単位で返す
+  - 送受信バイト数
+    - `sora_cluster_relay_received_bytes`
+    - `sora_cluster_relay_sent_bytes`
+  - 送受信パケット数
+    - `sora_cluster_relay_received_packets`
+    - `sora_cluster_relay_sent_packets`
+  - @tnamao
+
 ## 2024.2.0
 
 - [ADD] `sora_license_expired_at_timestamp_seconds` メトリクスを追加する

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -10,6 +10,11 @@ var (
 		raftState:       newDescWithLabel("cluster_raft_state", "The current Raft state. The state name is indicated by the label 'state'. The value of this metric is always set to 1.", []string{"state"}),
 		raftTerm:        newDesc("cluster_raft_term", "The current Raft term."),
 		raftCommitIndex: newDesc("cluster_raft_commit_index", "The latest committed Raft log index."),
+
+		clusterRelayReceivedBytes:   newDescWithLabel("cluster_relay_received_bytes", "The total number of bytes received by the cluster relay.", []string{"node_name"}),
+		clusterRelaySentBytes:       newDescWithLabel("cluster_relay_sent_bytes", "The total number of bytes sent by the cluster relay.", []string{"node_name"}),
+		clusterRelayReceivedPackets: newDescWithLabel("cluster_relay_received_packets", "The total number of packets received by the cluster relay.", []string{"node_name"}),
+		clusterRelaySentPackets:     newDescWithLabel("cluster_relay_sent_packets", "The total number of packets sent by the cluster relay.", []string{"node_name"}),
 	}
 )
 
@@ -18,6 +23,11 @@ type SoraClusterMetrics struct {
 	raftState       *prometheus.Desc
 	raftTerm        *prometheus.Desc
 	raftCommitIndex *prometheus.Desc
+
+	clusterRelayReceivedBytes   *prometheus.Desc
+	clusterRelaySentBytes       *prometheus.Desc
+	clusterRelayReceivedPackets *prometheus.Desc
+	clusterRelaySentPackets     *prometheus.Desc
 }
 
 func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
@@ -25,9 +35,13 @@ func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.raftState
 	ch <- m.raftTerm
 	ch <- m.raftCommitIndex
+	ch <- m.clusterRelayReceivedBytes
+	ch <- m.clusterRelaySentBytes
+	ch <- m.clusterRelayReceivedPackets
+	ch <- m.clusterRelaySentPackets
 }
 
-func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []soraClusterNode, report soraClusterReport) {
+func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []soraClusterNode, report soraClusterReport, clusterRelaies []soraClusterRelay) {
 	for _, node := range nodeList {
 		value := 0.0
 		if node.Connected {
@@ -42,4 +56,11 @@ func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []sor
 	ch <- newGauge(m.raftState, 1.0, report.RaftState)
 	ch <- newCounter(m.raftTerm, float64(report.RaftTerm))
 	ch <- newCounter(m.raftCommitIndex, float64(report.RaftCommitIndex))
+
+	for _, relayNode := range clusterRelaies {
+		ch <- newCounter(m.clusterRelayReceivedBytes, float64(relayNode.TotalReceivedByteSize), relayNode.NodeName)
+		ch <- newCounter(m.clusterRelaySentBytes, float64(relayNode.TotalSentByteSize), relayNode.NodeName)
+		ch <- newCounter(m.clusterRelayReceivedPackets, float64(relayNode.TotalReceived), relayNode.NodeName)
+		ch <- newCounter(m.clusterRelaySentPackets, float64(relayNode.TotalSent), relayNode.NodeName)
+	}
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -212,7 +212,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		c.ErlangVMMetrics.Collect(ch, report.ErlangVMReport)
 	}
 	if c.EnableSoraClusterMetrics {
-		c.SoraClusterMetrics.Collect(ch, nodeList, report.ClusterReport)
+		c.SoraClusterMetrics.Collect(ch, nodeList, report.ClusterReport, report.ClusterRelay)
 	}
 }
 

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -8,6 +8,7 @@ type soraGetStatsReport struct {
 	SoraConnectionErrorReport soraConnectionErrorReport `json:"error,omitempty"`
 	ErlangVMReport            erlangVMReport            `json:"erlang_vm,omitempty"`
 	ClusterReport             soraClusterReport         `json:"cluster,omitempty"`
+	ClusterRelay              []soraClusterRelay        `json:"cluster_relay,omitempty"`
 }
 
 type soraConnectionReport struct {
@@ -140,6 +141,14 @@ type soraClusterNode struct {
 	NodeName        string `json:"node_name"`
 	Mode            string `json:"mode"`
 	Connected       bool   `json:"connected"`
+}
+
+type soraClusterRelay struct {
+	NodeName              string `json:"node_name"`
+	TotalReceivedByteSize int64  `json:"total_received_byte_size"`
+	TotalSentByteSize     int64  `json:"total_sent_byte_size"`
+	TotalReceived         int64  `json:"total_received"`
+	TotalSent             int64  `json:"total_sent"`
 }
 
 type soraLicenseInfo struct {

--- a/main_test.go
+++ b/main_test.go
@@ -24,6 +24,22 @@ var (
                   "raft_state": "follower",
                   "raft_term": 3
                 },
+		"cluster_relay": [
+			{
+				"node_name": "node-01",
+				"total_received_byte_size": 11,
+				"total_sent_byte_size": 12,
+				"total_received": 13,
+				"total_sent": 14
+			},
+			{
+				"node_name": "node-02",
+				"total_received_byte_size": 21,
+				"total_sent_byte_size": 22,
+				"total_received": 23,
+				"total_sent": 24
+			}
+		],
 		"erlang_vm": {
 		  "memory": {
 			"total": 1234,

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -22,6 +22,22 @@ sora_cluster_raft_state{state="follower"} 1
 # HELP sora_cluster_raft_term The current Raft term.
 # TYPE sora_cluster_raft_term counter
 sora_cluster_raft_term 3
+# HELP sora_cluster_relay_received_bytes The total number of bytes received by the cluster relay.
+# TYPE sora_cluster_relay_received_bytes counter
+sora_cluster_relay_received_bytes{node_name="node-01"} 11
+sora_cluster_relay_received_bytes{node_name="node-02"} 21
+# HELP sora_cluster_relay_received_packets The total number of packets received by the cluster relay.
+# TYPE sora_cluster_relay_received_packets counter
+sora_cluster_relay_received_packets{node_name="node-01"} 13
+sora_cluster_relay_received_packets{node_name="node-02"} 23
+# HELP sora_cluster_relay_sent_bytes The total number of bytes sent by the cluster relay.
+# TYPE sora_cluster_relay_sent_bytes counter
+sora_cluster_relay_sent_bytes{node_name="node-01"} 12
+sora_cluster_relay_sent_bytes{node_name="node-02"} 22
+# HELP sora_cluster_relay_sent_packets The total number of packets sent by the cluster relay.
+# TYPE sora_cluster_relay_sent_packets counter
+sora_cluster_relay_sent_packets{node_name="node-01"} 14
+sora_cluster_relay_sent_packets{node_name="node-02"} 24
 # HELP sora_client_type_total The total number of connections by Sora client types
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -22,6 +22,22 @@ sora_cluster_raft_state{state="follower"} 1
 # HELP sora_cluster_raft_term The current Raft term.
 # TYPE sora_cluster_raft_term counter
 sora_cluster_raft_term 3
+# HELP sora_cluster_relay_received_bytes The total number of bytes received by the cluster relay.
+# TYPE sora_cluster_relay_received_bytes counter
+sora_cluster_relay_received_bytes{node_name="node-01"} 11
+sora_cluster_relay_received_bytes{node_name="node-02"} 21
+# HELP sora_cluster_relay_received_packets The total number of packets received by the cluster relay.
+# TYPE sora_cluster_relay_received_packets counter
+sora_cluster_relay_received_packets{node_name="node-01"} 13
+sora_cluster_relay_received_packets{node_name="node-02"} 23
+# HELP sora_cluster_relay_sent_bytes The total number of bytes sent by the cluster relay.
+# TYPE sora_cluster_relay_sent_bytes counter
+sora_cluster_relay_sent_bytes{node_name="node-01"} 12
+sora_cluster_relay_sent_bytes{node_name="node-02"} 22
+# HELP sora_cluster_relay_sent_packets The total number of packets sent by the cluster relay.
+# TYPE sora_cluster_relay_sent_packets counter
+sora_cluster_relay_sent_packets{node_name="node-01"} 14
+sora_cluster_relay_sent_packets{node_name="node-02"} 24
 # HELP sora_connections_total The total number of connections created.
 # TYPE sora_connections_total counter
 sora_connections_total{state="created"} 2


### PR DESCRIPTION
### 変更履歴

- [ADD] Sora のクラスターリレー機能のメトリクスを追加する
  - GetStatsReport API の `cluster_relay` 以下の統計情報を、起動オプションの `--sora.cluster-metrics` を有効にした時のみ収集する
  - 次のメトリクスを送受信しているノード単位で返す
  - 送受信バイト数
    - `sora_cluster_relay_received_bytes`
    - `sora_cluster_relay_sent_bytes`
  - 送受信パケット数
    - `sora_cluster_relay_received_packets`
    - `sora_cluster_relay_sent_packets`
  - @tnamao

---

This pull request primarily focuses on adding metrics for the Sora cluster relay feature. The changes include updates to several files to collect and display new metrics related to data sent and received by the cluster relay, such as the total number of bytes and packets sent and received. 

Here are the key changes:

Addition of new metrics:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R3-R13): Added a note about the new Sora cluster relay metrics feature.
* [`collector/cluster_node.go`](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR13-R17): Added new descriptors for the Sora cluster relay metrics in the `var` and `SoraClusterMetrics` structures. These descriptors are used to collect metrics on the total number of bytes and packets sent and received by the cluster relay. [[1]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR13-R17) [[2]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR26-R44)
* [`collector/cluster_node.go`](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR59-R65): Updated the `Collect` function in `SoraClusterMetrics` to include the new metrics for the cluster relay.

Structural changes for metrics collection:

* [`collector/collector.go`](diffhunk://#diff-bacda4196256b80bde6a1f6a6cc19d08e3309a4418a179ac4a730135bf950825L215-R215): Modified the `Collect` function in `Collector` to include the new cluster relay metrics.
* [`collector/sora_api.go`](diffhunk://#diff-d5b397c47e0a4309dc5dd54ae08bf261c3651be1a71c95b09b5701f90047174cR11): Added a new `soraClusterRelay` structure to hold the cluster relay metrics and updated the `soraGetStatsReport` structure to include these new metrics. [[1]](diffhunk://#diff-d5b397c47e0a4309dc5dd54ae08bf261c3651be1a71c95b09b5701f90047174cR11) [[2]](diffhunk://#diff-d5b397c47e0a4309dc5dd54ae08bf261c3651be1a71c95b09b5701f90047174cR146-R153)

Testing and validation:

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR27-R42): Updated the test data to include the new cluster relay metrics.
* `test/maximum.metrics` and `test/sora_cluster_metrics_enabled.metrics`: Updated the test metrics to validate the new cluster relay metrics. [[1]](diffhunk://#diff-f59a1e8fe7c71e1ed2ee047db128668aa25be5c668813fa60c05326bbe1ed008R25-R40) [[2]](diffhunk://#diff-af71e290dc9fe303ae574f91e3e07f39b9690d5c76019835d3ecc6fc43a91afaR25-R40)