### PR TITLE
Stats Webhook の統計情報に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## develop
 
+- [ADD] Sora の Stats Webhook の統計情報に対応する
+  - `sora_stats_webhook_total` メトリクスを追加し、ラベルに `successful` `failed` を設ける
+  - @tnamao
 - [UPDATE] CI の `actions/setup-go` を `v5` に上げる
   - @tnamao
 

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -37,6 +37,8 @@ type soraWebhookReport struct {
 	TotalFailedSessionWebhook     int64 `json:"total_failed_session_webhook"`
 	TotalSuccessfulEventWebhook   int64 `json:"total_successful_event_webhook"`
 	TotalFailedEventWebhook       int64 `json:"total_failed_event_webhook"`
+	TotalSuccessfulStatsWebhook   int64 `json:"total_successful_stats_webhook"`
+	TotalFailedStatsWebhook       int64 `json:"total_failed_stats_webhook"`
 }
 
 type soraClientStatistics struct {

--- a/collector/webhook.go
+++ b/collector/webhook.go
@@ -8,6 +8,7 @@ var (
 		totalAuthWebhook:           newDescWithLabel("auth_webhook_total", "The total number of auth webhook.", []string{"state"}),
 		totalSessionWebhook:        newDescWithLabel("session_webhook_total", "The total number of session webhook.", []string{"state"}),
 		totalEventWebhook:          newDescWithLabel("event_webhook_total", "The total number of event webhook.", []string{"state"}),
+		totalStatsWebhook:          newDescWithLabel("stats_webhook_total", "The total number of stats webhook.", []string{"state"}),
 	}
 )
 
@@ -16,6 +17,7 @@ type WebhookMetrics struct {
 	totalAuthWebhook           *prometheus.Desc
 	totalSessionWebhook        *prometheus.Desc
 	totalEventWebhook          *prometheus.Desc
+	totalStatsWebhook          *prometheus.Desc
 }
 
 func (m *WebhookMetrics) Describe(ch chan<- *prometheus.Desc) {
@@ -23,6 +25,7 @@ func (m *WebhookMetrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.totalAuthWebhook
 	ch <- m.totalSessionWebhook
 	ch <- m.totalEventWebhook
+	ch <- m.totalStatsWebhook
 }
 
 func (m *WebhookMetrics) Collect(ch chan<- prometheus.Metric, report soraWebhookReport) {
@@ -34,4 +37,6 @@ func (m *WebhookMetrics) Collect(ch chan<- prometheus.Metric, report soraWebhook
 	ch <- newCounter(m.totalSessionWebhook, float64(report.TotalFailedSessionWebhook), "failed")
 	ch <- newCounter(m.totalEventWebhook, float64(report.TotalSuccessfulEventWebhook), "successful")
 	ch <- newCounter(m.totalEventWebhook, float64(report.TotalFailedEventWebhook), "failed")
+	ch <- newCounter(m.totalStatsWebhook, float64(report.TotalSuccessfulStatsWebhook), "successful")
+	ch <- newCounter(m.totalStatsWebhook, float64(report.TotalFailedStatsWebhook), "failed")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -153,6 +153,7 @@ var (
 		"total_failed_connections": 0,
 		"total_failed_event_webhook": 94,
 		"total_failed_session_webhook": 95,
+		"total_failed_stats_webhook": 99,
 		"total_ongoing_connections": 0,
 		"total_received_invalid_turn_tcp_packet": 0,
 		"total_session_created": 1,
@@ -161,6 +162,7 @@ var (
 		"total_successful_connections": 2,
 		"total_successful_event_webhook": 97,
 		"total_successful_session_webhook": 98,
+		"total_successful_stats_webhook": 100,
 		"total_turn_tcp_connections": 2,
 		"total_turn_udp_connections": 0,
 		"version": "2022.1.0-canary.28"
@@ -398,6 +400,7 @@ func TestMinimumMetrics(t *testing.T) {
 		"total_failed_connections": 100,
 		"total_failed_event_webhook": 94,
 		"total_failed_session_webhook": 95,
+		"total_failed_stats_webhook": 99,
 		"total_ongoing_connections": 88,
 		"total_received_invalid_turn_tcp_packet": 123,
 		"total_session_created": 111,
@@ -406,6 +409,7 @@ func TestMinimumMetrics(t *testing.T) {
 		"total_successful_connections": 333,
 		"total_successful_event_webhook": 97,
 		"total_successful_session_webhook": 98,
+		"total_successful_stats_webhook": 100,
 		"total_turn_tcp_connections": 444,
 		"total_turn_udp_connections": 555,
 		"version": "2022.1.0-canary.28"

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -191,6 +191,10 @@ sora_session_total{state="destroyed"} 0
 # TYPE sora_session_webhook_total counter
 sora_session_webhook_total{state="failed"} 95
 sora_session_webhook_total{state="successful"} 98
+# HELP sora_stats_webhook_total The total number of stats webhook.
+# TYPE sora_stats_webhook_total counter
+sora_stats_webhook_total{state="failed"} 99
+sora_stats_webhook_total{state="successful"} 100
 # HELP sora_successful_auth_webhook_total The total number of successful auth webhook.
 # TYPE sora_successful_auth_webhook_total counter
 sora_successful_auth_webhook_total{state="allowed"} 91

--- a/test/minimum.metrics
+++ b/test/minimum.metrics
@@ -45,6 +45,10 @@ sora_session_total{state="destroyed"} 222
 # TYPE sora_session_webhook_total counter
 sora_session_webhook_total{state="failed"} 95
 sora_session_webhook_total{state="successful"} 98
+# HELP sora_stats_webhook_total The total number of stats webhook.
+# TYPE sora_stats_webhook_total counter
+sora_stats_webhook_total{state="failed"} 99
+sora_stats_webhook_total{state="successful"} 100
 # HELP sora_successful_auth_webhook_total The total number of successful auth webhook.
 # TYPE sora_successful_auth_webhook_total counter
 sora_successful_auth_webhook_total{state="allowed"} 91

--- a/test/sora_client_enabled.metrics
+++ b/test/sora_client_enabled.metrics
@@ -76,6 +76,10 @@ sora_session_total{state="destroyed"} 0
 # TYPE sora_session_webhook_total counter
 sora_session_webhook_total{state="failed"} 95
 sora_session_webhook_total{state="successful"} 98
+# HELP sora_stats_webhook_total The total number of stats webhook.
+# TYPE sora_stats_webhook_total counter
+sora_stats_webhook_total{state="failed"} 99
+sora_stats_webhook_total{state="successful"} 100
 # HELP sora_successful_auth_webhook_total The total number of successful auth webhook.
 # TYPE sora_successful_auth_webhook_total counter
 sora_successful_auth_webhook_total{state="allowed"} 91

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -78,6 +78,10 @@ sora_session_total{state="destroyed"} 0
 # TYPE sora_session_webhook_total counter
 sora_session_webhook_total{state="failed"} 95
 sora_session_webhook_total{state="successful"} 98
+# HELP sora_stats_webhook_total The total number of stats webhook.
+# TYPE sora_stats_webhook_total counter
+sora_stats_webhook_total{state="failed"} 99
+sora_stats_webhook_total{state="successful"} 100
 # HELP sora_successful_auth_webhook_total The total number of successful auth webhook.
 # TYPE sora_successful_auth_webhook_total counter
 sora_successful_auth_webhook_total{state="allowed"} 91

--- a/test/sora_connection_error_enabled.metrics
+++ b/test/sora_connection_error_enabled.metrics
@@ -52,6 +52,10 @@ sora_session_total{state="destroyed"} 0
 # TYPE sora_session_webhook_total counter
 sora_session_webhook_total{state="failed"} 95
 sora_session_webhook_total{state="successful"} 98
+# HELP sora_stats_webhook_total The total number of stats webhook.
+# TYPE sora_stats_webhook_total counter
+sora_stats_webhook_total{state="failed"} 99
+sora_stats_webhook_total{state="successful"} 100
 # HELP sora_successful_auth_webhook_total The total number of successful auth webhook.
 # TYPE sora_successful_auth_webhook_total counter
 sora_successful_auth_webhook_total{state="allowed"} 91

--- a/test/sora_erlang_vm_enabled.metrics
+++ b/test/sora_erlang_vm_enabled.metrics
@@ -129,6 +129,10 @@ sora_session_total{state="destroyed"} 0
 # TYPE sora_session_webhook_total counter
 sora_session_webhook_total{state="failed"} 95
 sora_session_webhook_total{state="successful"} 98
+# HELP sora_stats_webhook_total The total number of stats webhook.
+# TYPE sora_stats_webhook_total counter
+sora_stats_webhook_total{state="failed"} 99
+sora_stats_webhook_total{state="successful"} 100
 # HELP sora_successful_auth_webhook_total The total number of successful auth webhook.
 # TYPE sora_successful_auth_webhook_total counter
 sora_successful_auth_webhook_total{state="allowed"} 91


### PR DESCRIPTION
### 変更履歴

- [ADD] Sora の Stats Webhook の統計情報に対応する
  - `sora_stats_webhook_total` メトリクスを追加し、ラベルに `successful` `failed` を設ける
  - @tnamao

---

This pull request primarily focuses on enhancing the Sora Stats Webhook's statistical information. The changes include the addition of `totalStatsWebhook` to the `WebhookMetrics` struct, updates to the `soraWebhookReport` struct, and modifications to various test files to accommodate the new stats webhook metrics. 

Additions to the Webhook Metrics and Sora Webhook Report:

* [`collector/sora_api.go`](diffhunk://#diff-d5b397c47e0a4309dc5dd54ae08bf261c3651be1a71c95b09b5701f90047174cR40-R41): Added `TotalSuccessfulStatsWebhook` and `TotalFailedStatsWebhook` to the `soraWebhookReport` struct. This allows the collection of successful and failed stats webhook data.
* [`collector/webhook.go`](diffhunk://#diff-9ce1f8e51b855f1919680a60a4e4325f7705455634bde71a7a4a3f413c6727beR11): Added `totalStatsWebhook` to the `WebhookMetrics` struct and the `Describe` method. This enables the description of the total number of stats webhooks. [[1]](diffhunk://#diff-9ce1f8e51b855f1919680a60a4e4325f7705455634bde71a7a4a3f413c6727beR11) [[2]](diffhunk://#diff-9ce1f8e51b855f1919680a60a4e4325f7705455634bde71a7a4a3f413c6727beR20-R28)
* [`collector/webhook.go`](diffhunk://#diff-9ce1f8e51b855f1919680a60a4e4325f7705455634bde71a7a4a3f413c6727beR40-R41): Updated the `Collect` method to include counters for successful and failed stats webhooks. This ensures that these metrics are collected.

Updates to Test Files:

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR156): Added `total_failed_stats_webhook` and `total_successful_stats_webhook` to the test data in various places. This ensures that the new stats webhook metrics are included in the tests. [[1]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR156) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR165) [[3]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR403) [[4]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR412)
* Various metrics test files: Added entries for `sora_stats_webhook_total` for both successful and failed states. This ensures that the new stats webhook metrics are included in the metrics tests. [[1]](diffhunk://#diff-f59a1e8fe7c71e1ed2ee047db128668aa25be5c668813fa60c05326bbe1ed008R194-R197) [[2]](diffhunk://#diff-8eb563d1217cba053eb07ffa0af5ae2d054d2d07a896a82bfd92c6fe54f98ce7R48-R51) [[3]](diffhunk://#diff-70ed77c8e411aebb87bb471be9d0449aeedc2988e3db5f2b584e77869fd4a146R79-R82) [[4]](diffhunk://#diff-af71e290dc9fe303ae574f91e3e07f39b9690d5c76019835d3ecc6fc43a91afaR81-R84) [[5]](diffhunk://#diff-a056cc3ffbdc6505820ed188aecbfb08f56491d0f369dd8be0d4e5db63aaf4f9R55-R58) [[6]](diffhunk://#diff-f212054afc8d698732b1b054115aabb7a8c37cce2025c3cb623e5004a0f69a27R132-R135)

Documentation Update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R5-R7): Documented the addition of the Sora Stats Webhook statistics.