### PR TITLE
メトリクスのテンポラリーノード対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## develop
+
+- [ADD] `sora_cluster_node` のメトリクスに `node_type` を追加する
+  - `regular` または `temporary` のいずれかが入ります
+  - @tnamao
+
 ## 2024.5.0
 
 - [ADD] Sora の Stats Webhook の統計情報に対応する

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -144,6 +144,7 @@ type soraClusterNode struct {
 	NodeName        string `json:"node_name"`
 	Mode            string `json:"mode"`
 	Connected       bool   `json:"connected"`
+	TemporaryNode   bool   `json:"temporary_node"`
 }
 
 type soraClusterRelay struct {

--- a/main_test.go
+++ b/main_test.go
@@ -184,7 +184,8 @@ var (
 		  "license_max_connections": 100,
 		  "license_serial_code": "SAMPLE-SRA-E001-202212-N10-100",
 		  "license_type": "Experimental",
-		  "connected": true
+		  "connected": true,
+		  "temporary_node": false
 		},
 		{
 			"node_name": "node-03_canary_sora@10.211.55.41",
@@ -198,7 +199,8 @@ var (
 			"license_max_connections": 100,
 			"license_serial_code": "SAMPLE-SRA-E001-202212-N10-100",
 			"license_type": "Experimental",
-			"connected": true
+			"connected": true,
+			"temporary_node": true
 		  }
 		]`
 	listClusterNodesCurrentJSONData = `[
@@ -217,7 +219,8 @@ var (
 		  "license_type": "Experimental",
 		  "cluster_signaling_url": "ws://127.0.0.1:5002/signaling",
 		  "cluster_api_url": "http://10.1.1.3:3000/",
-		  "connected": true
+		  "connected": true,
+		  "temporary_node": false
 		},
 		{
 			"node_name": "node-03_canary_sora@10.211.55.41",
@@ -231,7 +234,8 @@ var (
 			"license_max_connections": 100,
 			"license_serial_code": "SAMPLE-SRA-E001-202212-N10-100",
 			"license_type": "Experimental",
-			"connected": true
+			"connected": true,
+			"temporary_node": true
 		  }
 	  ]`
 	getLicenseJSONDATA = `{

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -10,9 +10,9 @@ sora_average_duration_seconds 706
 sora_average_setup_time_seconds 0
 # HELP sora_cluster_node The sora server known cluster node.
 # TYPE sora_cluster_node gauge
-sora_cluster_node{mode="",node_name="node-01_canary_sora@10.211.55.42"} 0
-sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40"} 1
-sora_cluster_node{mode="normal",node_name="node-03_canary_sora@10.211.55.41"} 1
+sora_cluster_node{mode="",node_name="node-01_canary_sora@10.211.55.42",node_type="regular"} 0
+sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40",node_type="regular"} 1
+sora_cluster_node{mode="normal",node_name="node-03_canary_sora@10.211.55.41",node_type="temporary"} 1
 # HELP sora_cluster_raft_commit_index The latest committed Raft log index.
 # TYPE sora_cluster_raft_commit_index counter
 sora_cluster_raft_commit_index 10

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -10,9 +10,9 @@ sora_average_duration_seconds 706
 sora_average_setup_time_seconds 0
 # HELP sora_cluster_node The sora server known cluster node.
 # TYPE sora_cluster_node gauge
-sora_cluster_node{mode="normal",node_name="node-03_canary_sora@10.211.55.41"} 1
-sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40"} 1
-sora_cluster_node{mode="",node_name="node-01_canary_sora@10.211.55.42"} 0
+sora_cluster_node{mode="normal",node_name="node-03_canary_sora@10.211.55.41",node_type="temporary"} 1
+sora_cluster_node{mode="block_new_connection",node_name="node-02_canary_sora@10.211.55.40",node_type="regular"} 1
+sora_cluster_node{mode="",node_name="node-01_canary_sora@10.211.55.42",node_type="regular"} 0
 # HELP sora_cluster_raft_commit_index The latest committed Raft log index.
 # TYPE sora_cluster_raft_commit_index counter
 sora_cluster_raft_commit_index 10


### PR DESCRIPTION
### 変更履歴

- [ADD] `sora_cluster_node` のメトリクスに `node_type` を追加する
  - `regular` または `temporary` のいずれかが入ります
  - @tnamao

---

This pull request primarily introduces a new `node_type` attribute to the `sora_cluster_node` metrics in the Sora server. This attribute can either be `regular` or `temporary`, depending on whether the node is a temporary one. The changes also include updates to the test data and metrics files to reflect this new attribute.

Here are the key changes:

Updates to `sora_cluster_node` metrics:

* [`collector/cluster_node.go`](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceL9-R9): The `node_type` attribute was added to the `soraClusterMetrics` variable, and the logic to determine the `node_type` was added to the `Collect` method of `SoraClusterMetrics`. [[1]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceL9-R9) [[2]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR50-R59)
* [`collector/sora_api.go`](diffhunk://#diff-d5b397c47e0a4309dc5dd54ae08bf261c3651be1a71c95b09b5701f90047174cR147): The `soraClusterNode` struct was updated to include the `TemporaryNode` boolean attribute.

Updates to test data:

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL187-R188): The test data was updated to include the `temporary_node` attribute. [[1]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL187-R188) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL201-R203) [[3]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL220-R223) [[4]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL234-R238)

Updates to metrics files:

* `test/maximum.metrics` and `test/sora_cluster_metrics_enabled.metrics`: The `sora_cluster_node` metrics were updated to include the `node_type` attribute. [[1]](diffhunk://#diff-f59a1e8fe7c71e1ed2ee047db128668aa25be5c668813fa60c05326bbe1ed008L13-R15) [[2]](diffhunk://#diff-af71e290dc9fe303ae574f91e3e07f39b9690d5c76019835d3ecc6fc43a91afaL13-R15)

Documentation update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R3-R8): The addition of the `node_type` attribute to the `sora_cluster_node` metrics was documented.