### PR TITLE
cluster_relay_plumtree_received_gossip_hop_total メトリクス (Sora 2025.1.0 で導入予定) を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   - Sora 2025.1.0 で Sora API の GetStatsReport API に追加される予定の多段リレー関連の以下のメトリクスを追加する
     - `cluster_relay_plumtree_sent_gossip_total`
     - `cluster_relay_plumtree_received_gossip_total`
+    - `cluster_relay_plumtree_received_gossip_hop_total`
     - `cluster_relay_plumtree_sent_ihave_total`
     - `cluster_relay_plumtree_received_ihave_total`
     - `cluster_relay_plumtree_sent_graft_total`

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -18,6 +18,7 @@ var (
 
 		clusterRelayPlumtreeSentGossipTotal:   newDescWithLabel("cluster_relay_plumtree_sent_gossip_total", "The total number of Plumtree GOSSIP messages sent by the cluster relay.", []string{"node_name"}),
 		clusterRelayPlumtreeReceivedGossipTotal:   newDescWithLabel("cluster_relay_plumtree_received_gossip_total", "The total number of Plumtree GOSSIP messages received by the cluster relay.", []string{"node_name"}),
+		clusterRelayPlumtreeReceivedGossipHopTotal:   newDescWithLabel("cluster_relay_plumtree_received_gossip_hop_total", "The total number of hop count of Plumtree GOSSIP messages received by the cluster relay.", []string{"node_name"}),
 		clusterRelayPlumtreeSentIhaveTotal:   newDescWithLabel("cluster_relay_plumtree_sent_ihave_total", "The total number of Plumtree IHAVE messages sent by the cluster relay.", []string{"node_name"}),
 		clusterRelayPlumtreeReceivedIhaveTotal:   newDescWithLabel("cluster_relay_plumtree_received_ihave_total", "The total number of Plumtree IHAVE messages received by the cluster relay.", []string{"node_name"}),
 		clusterRelayPlumtreeSentGraftTotal:   newDescWithLabel("cluster_relay_plumtree_sent_graft_total", "The total number of Plumtree GRAFT messages sent by the cluster relay.", []string{"node_name"}),
@@ -41,17 +42,18 @@ type SoraClusterMetrics struct {
 	clusterRelayReceivedPacketsTotal *prometheus.Desc
 	clusterRelaySentPacketsTotal     *prometheus.Desc
 
-	clusterRelayPlumtreeSentGossipTotal     *prometheus.Desc
-	clusterRelayPlumtreeReceivedGossipTotal *prometheus.Desc
-	clusterRelayPlumtreeSentIhaveTotal      *prometheus.Desc
-	clusterRelayPlumtreeReceivedIhaveTotal  *prometheus.Desc
-	clusterRelayPlumtreeSentGraftTotal      *prometheus.Desc
-	clusterRelayPlumtreeReceivedGraftTotal  *prometheus.Desc
-	clusterRelayPlumtreeSentPruneTotal      *prometheus.Desc
-	clusterRelayPlumtreeReceivedPruneTotal  *prometheus.Desc
-	clusterRelayPlumtreeGraftMissTotal      *prometheus.Desc
-	clusterRelayPlumtreeSkippedSendTotal    *prometheus.Desc
-	clusterRelayPlumtreeIgnoredTotal        *prometheus.Desc
+	clusterRelayPlumtreeSentGossipTotal        *prometheus.Desc
+	clusterRelayPlumtreeReceivedGossipTotal    *prometheus.Desc
+	clusterRelayPlumtreeReceivedGossipHopTotal *prometheus.Desc
+	clusterRelayPlumtreeSentIhaveTotal         *prometheus.Desc
+	clusterRelayPlumtreeReceivedIhaveTotal     *prometheus.Desc
+	clusterRelayPlumtreeSentGraftTotal         *prometheus.Desc
+	clusterRelayPlumtreeReceivedGraftTotal     *prometheus.Desc
+	clusterRelayPlumtreeSentPruneTotal         *prometheus.Desc
+	clusterRelayPlumtreeReceivedPruneTotal     *prometheus.Desc
+	clusterRelayPlumtreeGraftMissTotal         *prometheus.Desc
+	clusterRelayPlumtreeSkippedSendTotal       *prometheus.Desc
+	clusterRelayPlumtreeIgnoredTotal           *prometheus.Desc
 }
 
 func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
@@ -65,6 +67,7 @@ func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.clusterRelaySentPacketsTotal
 	ch <- m.clusterRelayPlumtreeSentGossipTotal
 	ch <- m.clusterRelayPlumtreeReceivedGossipTotal
+	ch <- m.clusterRelayPlumtreeReceivedGossipHopTotal
 	ch <- m.clusterRelayPlumtreeSentIhaveTotal
 	ch <- m.clusterRelayPlumtreeReceivedIhaveTotal
 	ch <- m.clusterRelayPlumtreeSentGraftTotal
@@ -106,6 +109,7 @@ func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []sor
 
 		ch <- newCounter(m.clusterRelayPlumtreeSentGossipTotal, float64(relayNode.Plumtree.TotalSentGossip), relayNode.NodeName)
 		ch <- newCounter(m.clusterRelayPlumtreeReceivedGossipTotal, float64(relayNode.Plumtree.TotalReceivedGossip), relayNode.NodeName)
+		ch <- newCounter(m.clusterRelayPlumtreeReceivedGossipHopTotal, float64(relayNode.Plumtree.TotalReceivedGossipHop), relayNode.NodeName)
 		ch <- newCounter(m.clusterRelayPlumtreeSentIhaveTotal, float64(relayNode.Plumtree.TotalSentIhave), relayNode.NodeName)
 		ch <- newCounter(m.clusterRelayPlumtreeReceivedIhaveTotal, float64(relayNode.Plumtree.TotalReceivedIhave), relayNode.NodeName)
 		ch <- newCounter(m.clusterRelayPlumtreeSentGraftTotal, float64(relayNode.Plumtree.TotalSentGraft), relayNode.NodeName)

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -179,17 +179,18 @@ type soraClusterRelay struct {
 }
 
 type soraClusterRelayPlumtree struct {
-        TotalSentGossip     int64 `json:"total_sent_gossip"`
-        TotalReceivedGossip int64 `json:"total_received_gossip"`
-        TotalSentIhave      int64 `json:"total_sent_ihave"`
-        TotalReceivedIhave  int64 `json:"total_received_ihave"`
-        TotalSentGraft      int64 `json:"total_sent_graft"`
-        TotalReceivedGraft  int64 `json:"total_received_graft"`
-        TotalSentPrune      int64 `json:"total_sent_prune"`
-        TotalReceivedPrune  int64 `json:"total_received_prune"`
-        TotalGraftMiss      int64 `json:"total_graft_miss"`
-        TotalSkippedSend    int64 `json:"total_skipped_send"`
-        TotalIgnored        int64 `json:"total_ignored"`
+        TotalSentGossip        int64 `json:"total_sent_gossip"`
+        TotalReceivedGossip    int64 `json:"total_received_gossip"`
+        TotalReceivedGossipHop int64 `json:"total_received_gossip_hop"`
+        TotalSentIhave         int64 `json:"total_sent_ihave"`
+        TotalReceivedIhave     int64 `json:"total_received_ihave"`
+        TotalSentGraft         int64 `json:"total_sent_graft"`
+        TotalReceivedGraft     int64 `json:"total_received_graft"`
+        TotalSentPrune         int64 `json:"total_sent_prune"`
+        TotalReceivedPrune     int64 `json:"total_received_prune"`
+        TotalGraftMiss         int64 `json:"total_graft_miss"`
+        TotalSkippedSend       int64 `json:"total_skipped_send"`
+        TotalIgnored           int64 `json:"total_ignored"`
 }
 
 type soraLicenseInfo struct {

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,7 @@ var (
 				"plumtree": {
 					"total_sent_gossip": 1,
 					"total_received_gossip": 2,
+					"total_received_gossip_hop": 4,
 					"total_sent_ihave": 3,
 					"total_received_ihave": 4,
 					"total_sent_graft": 5,
@@ -55,6 +56,7 @@ var (
 				"plumtree": {
 					"total_sent_gossip": 101,
 					"total_received_gossip": 102,
+					"total_received_gossip_hop": 150,
 					"total_sent_ihave": 103,
 					"total_received_ihave": 104,
 					"total_sent_graft": 105,

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -50,6 +50,10 @@ sora_cluster_relay_plumtree_ignored_total{node_name="node-02"} 111
 # TYPE sora_cluster_relay_plumtree_received_gossip_total counter
 sora_cluster_relay_plumtree_received_gossip_total{node_name="node-01"} 2
 sora_cluster_relay_plumtree_received_gossip_total{node_name="node-02"} 102
+# HELP sora_cluster_relay_plumtree_received_gossip_hop_total The total number of hop count of Plumtree GOSSIP messages received by the cluster relay.
+# TYPE sora_cluster_relay_plumtree_received_gossip_hop_total counter
+sora_cluster_relay_plumtree_received_gossip_hop_total{node_name="node-01"} 4
+sora_cluster_relay_plumtree_received_gossip_hop_total{node_name="node-02"} 150
 # HELP sora_cluster_relay_plumtree_received_graft_total The total number of Plumtree GRAFT messages received by the cluster relay.
 # TYPE sora_cluster_relay_plumtree_received_graft_total counter
 sora_cluster_relay_plumtree_received_graft_total{node_name="node-01"} 6

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -50,6 +50,10 @@ sora_cluster_relay_plumtree_ignored_total{node_name="node-02"} 111
 # TYPE sora_cluster_relay_plumtree_received_gossip_total counter
 sora_cluster_relay_plumtree_received_gossip_total{node_name="node-01"} 2
 sora_cluster_relay_plumtree_received_gossip_total{node_name="node-02"} 102
+# HELP sora_cluster_relay_plumtree_received_gossip_hop_total The total number of hop count of Plumtree GOSSIP messages received by the cluster relay.
+# TYPE sora_cluster_relay_plumtree_received_gossip_hop_total counter
+sora_cluster_relay_plumtree_received_gossip_hop_total{node_name="node-01"} 4
+sora_cluster_relay_plumtree_received_gossip_hop_total{node_name="node-02"} 150
 # HELP sora_cluster_relay_plumtree_received_graft_total The total number of Plumtree GRAFT messages received by the cluster relay.
 # TYPE sora_cluster_relay_plumtree_received_graft_total counter
 sora_cluster_relay_plumtree_received_graft_total{node_name="node-01"} 6


### PR DESCRIPTION
https://github.com/shiguredo/sora_exporter/pull/47 のフォローアップ PR です。
新たにリレー時のメッセージホップ回数用の統計値が追加されたので対応しました。

---

This pull request introduces several new metrics related to the Plumtree protocol and SRTP delay for the Sora API. The changes span multiple files, adding new descriptors, updating structures, and modifying test cases to support these new metrics.

### New Metrics Added:

* `collector/cluster_node.go`: 
  - Added descriptors for multiple Plumtree-related metrics, such as `cluster_relay_plumtree_sent_gossip_total`, `cluster_relay_plumtree_received_gossip_total`, and others. [[1]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR18-R30) [[2]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR44-R56) [[3]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR68-R79) [[4]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR109-R121)
  - Updated `SoraClusterMetrics` struct to include new Plumtree metrics.
  - Updated `Collect` and `Describe` methods to handle the new Plumtree metrics. [[1]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR68-R79) [[2]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR109-R121)

* `collector/sora_api.go`:
  - Added `TotalSentSrtpSfuDelayUs` to the `soraSrtpReport` struct.
  - Added `Plumtree` field to `soraClusterRelay` struct and defined a new `soraClusterRelayPlumtree` struct for Plumtree metrics.

* `collector/srtp.go`:
  - Added descriptor for `totalSentSrtpSfuDelayUs` metric.
  - Updated `SrtpMetrics` struct and methods to include the new SRTP delay metric. [[1]](diffhunk://#diff-0b2f8413a1a8c664d57a745db174bd5b336f87befed75fa3ea09117f9eee1c15R22) [[2]](diffhunk://#diff-0b2f8413a1a8c664d57a745db174bd5b336f87befed75fa3ea09117f9eee1c15R32) [[3]](diffhunk://#diff-0b2f8413a1a8c664d57a745db174bd5b336f87befed75fa3ea09117f9eee1c15R42)

### Documentation and Test Updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R12-R32): Documented the addition of new metrics for Plumtree and SRTP delay.

* `main_test.go`: 
  - Updated test data to include Plumtree metrics in the `TestMinimumMetrics` function and other relevant test cases. [[1]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL34-R69) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR197) [[3]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR467)

* Metric files (`test/maximum.metrics`, `test/minimum.metrics`, `test/sora_client_enabled.metrics`):
  - Added entries for the new Plumtree and SRTP delay metrics. [[1]](diffhunk://#diff-f59a1e8fe7c71e1ed2ee047db128668aa25be5c668813fa60c05326bbe1ed008R41-R88) [[2]](diffhunk://#diff-f59a1e8fe7c71e1ed2ee047db128668aa25be5c668813fa60c05326bbe1ed008R271-R273) [[3]](diffhunk://#diff-8eb563d1217cba053eb07ffa0af5ae2d054d2d07a896a82bfd92c6fe54f98ce7R77-R79) [[4]](diffhunk://#diff-70ed77c8e411aebb87bb471be9d0449aeedc2988e3db5f2b584e77869fd4a146R108-R110)