### PR TITLE
Sora の 2025.1.0 で導入予定の cluster_relay_plumtree_ihave_overflow_total メトリクスを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
     - `cluster_relay_plumtree_received_prune_total`
     - `cluster_relay_plumtree_graft_miss_total`
     - `cluster_relay_plumtree_skipped_send_total`
+    - `cluster_relay_plumtree_ihave_overflow_total`
     - `cluster_relay_plumtree_ignored_total`
   - @sile
 - [ADD] `sora_srtp_sent_sfu_delay_us_total` メトリクスを追加する

--- a/collector/cluster_node.go
+++ b/collector/cluster_node.go
@@ -27,6 +27,7 @@ var (
 		clusterRelayPlumtreeReceivedPruneTotal:   newDescWithLabel("cluster_relay_plumtree_received_prune_total", "The total number of Plumtree PRUNE messages received by the cluster relay.", []string{"node_name"}),
 		clusterRelayPlumtreeGraftMissTotal:   newDescWithLabel("cluster_relay_plumtree_graft_miss_total", "The total number of Plumtree GRAFT messages missed by the cluster relay.", []string{"node_name"}),
 		clusterRelayPlumtreeSkippedSendTotal:   newDescWithLabel("cluster_relay_plumtree_skipped_send_total", "The total number of Plumtree messages whose sending was skipped by the cluster relay.", []string{"node_name"}),
+		clusterRelayPlumtreeIhaveOverflowTotal:   newDescWithLabel("cluster_relay_plumtree_ihave_overflow_total", "The total number of Plumtree IHAVE messages that were discarded upon reception by the cluster relay due to exceeding the maximum queue size.", []string{"node_name"}),
 		clusterRelayPlumtreeIgnoredTotal:   newDescWithLabel("cluster_relay_plumtree_ignored_total", "The total number of Plumtree messages received but ignored by the cluster relay.", []string{"node_name"}),
 	}
 )
@@ -53,6 +54,7 @@ type SoraClusterMetrics struct {
 	clusterRelayPlumtreeReceivedPruneTotal     *prometheus.Desc
 	clusterRelayPlumtreeGraftMissTotal         *prometheus.Desc
 	clusterRelayPlumtreeSkippedSendTotal       *prometheus.Desc
+	clusterRelayPlumtreeIhaveOverflowTotal     *prometheus.Desc
 	clusterRelayPlumtreeIgnoredTotal           *prometheus.Desc
 }
 
@@ -76,6 +78,7 @@ func (m *SoraClusterMetrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.clusterRelayPlumtreeReceivedPruneTotal
 	ch <- m.clusterRelayPlumtreeGraftMissTotal
 	ch <- m.clusterRelayPlumtreeSkippedSendTotal
+	ch <- m.clusterRelayPlumtreeIhaveOverflowTotal
 	ch <- m.clusterRelayPlumtreeIgnoredTotal
 }
 
@@ -118,6 +121,7 @@ func (m *SoraClusterMetrics) Collect(ch chan<- prometheus.Metric, nodeList []sor
 		ch <- newCounter(m.clusterRelayPlumtreeReceivedPruneTotal, float64(relayNode.Plumtree.TotalReceivedPrune), relayNode.NodeName)
 		ch <- newCounter(m.clusterRelayPlumtreeGraftMissTotal, float64(relayNode.Plumtree.TotalGraftMiss), relayNode.NodeName)
 		ch <- newCounter(m.clusterRelayPlumtreeSkippedSendTotal, float64(relayNode.Plumtree.TotalSkippedSend), relayNode.NodeName)
+		ch <- newCounter(m.clusterRelayPlumtreeIhaveOverflowTotal, float64(relayNode.Plumtree.TotalIhaveOverflow), relayNode.NodeName)
 		ch <- newCounter(m.clusterRelayPlumtreeIgnoredTotal, float64(relayNode.Plumtree.TotalIgnored), relayNode.NodeName)
 	}
 }

--- a/collector/sora_api.go
+++ b/collector/sora_api.go
@@ -190,6 +190,7 @@ type soraClusterRelayPlumtree struct {
         TotalReceivedPrune     int64 `json:"total_received_prune"`
         TotalGraftMiss         int64 `json:"total_graft_miss"`
         TotalSkippedSend       int64 `json:"total_skipped_send"`
+        TotalIhaveOverflow     int64 `json:"total_ihave_overflow"`
         TotalIgnored           int64 `json:"total_ignored"`
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -44,6 +44,7 @@ var (
 					"total_received_prune": 8,
 					"total_graft_miss": 9,
 					"total_skipped_send": 10,
+					"total_ihave_overflow": 2,
 					"total_ignored": 11
                                 }
 			},
@@ -65,6 +66,7 @@ var (
 					"total_received_prune": 108,
 					"total_graft_miss": 109,
 					"total_skipped_send": 110,
+					"total_ihave_overflow": 3,
 					"total_ignored": 111
                                 }
 			}

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -88,8 +88,8 @@ sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 10
 sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 110
 # HELP sora_cluster_relay_plumtree_ihave_overflow_total The total number of Plumtree IHAVE messages that were discarded upon reception by the cluster relay due to exceeding the maximum queue size.
 # TYPE sora_cluster_relay_plumtree_ihave_overflow_total counter
-sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 2
-sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 3
+sora_cluster_relay_plumtree_ihave_overflow_total{node_name="node-01"} 2
+sora_cluster_relay_plumtree_ihave_overflow_total{node_name="node-02"} 3
 # HELP sora_client_type_total The total number of connections by Sora client types
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1

--- a/test/maximum.metrics
+++ b/test/maximum.metrics
@@ -86,6 +86,10 @@ sora_cluster_relay_plumtree_sent_prune_total{node_name="node-02"} 107
 # TYPE sora_cluster_relay_plumtree_skipped_send_total counter
 sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 10
 sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 110
+# HELP sora_cluster_relay_plumtree_ihave_overflow_total The total number of Plumtree IHAVE messages that were discarded upon reception by the cluster relay due to exceeding the maximum queue size.
+# TYPE sora_cluster_relay_plumtree_ihave_overflow_total counter
+sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 2
+sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 3
 # HELP sora_client_type_total The total number of connections by Sora client types
 # TYPE sora_client_type_total counter
 sora_client_type_total{client="android_sdk",state="failed"} 1

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -88,8 +88,8 @@ sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 10
 sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 110
 # HELP sora_cluster_relay_plumtree_ihave_overflow_total The total number of Plumtree IHAVE messages that were discarded upon reception by the cluster relay due to exceeding the maximum queue size.
 # TYPE sora_cluster_relay_plumtree_ihave_overflow_total counter
-sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 2
-sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 3
+sora_cluster_relay_plumtree_ihave_overflow_total{node_name="node-01"} 2
+sora_cluster_relay_plumtree_ihave_overflow_total{node_name="node-02"} 3
 # HELP sora_connections_total The total number of connections created.
 # TYPE sora_connections_total counter
 sora_connections_total{state="created"} 2

--- a/test/sora_cluster_metrics_enabled.metrics
+++ b/test/sora_cluster_metrics_enabled.metrics
@@ -86,6 +86,10 @@ sora_cluster_relay_plumtree_sent_prune_total{node_name="node-02"} 107
 # TYPE sora_cluster_relay_plumtree_skipped_send_total counter
 sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 10
 sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 110
+# HELP sora_cluster_relay_plumtree_ihave_overflow_total The total number of Plumtree IHAVE messages that were discarded upon reception by the cluster relay due to exceeding the maximum queue size.
+# TYPE sora_cluster_relay_plumtree_ihave_overflow_total counter
+sora_cluster_relay_plumtree_skipped_send_total{node_name="node-01"} 2
+sora_cluster_relay_plumtree_skipped_send_total{node_name="node-02"} 3
 # HELP sora_connections_total The total number of connections created.
 # TYPE sora_connections_total counter
 sora_connections_total{state="created"} 2


### PR DESCRIPTION
This pull request introduces a new metric, `cluster_relay_plumtree_ihave_overflow_total`, to track the number of Plumtree IHAVE messages discarded due to exceeding the maximum queue size. Changes span across multiple files to integrate this metric into the system, update relevant structures, and ensure proper testing coverage.

### Addition of the new metric:

* **Metric definition and integration:**
  - Added `cluster_relay_plumtree_ihave_overflow_total` to `CHANGES.md` for documentation.
  - Defined the metric in `collector/cluster_node.go` with a description and integrated it into the `SoraClusterMetrics` struct, `Describe`, and `Collect` methods. [[1]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR30) [[2]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR57) [[3]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR81) [[4]](diffhunk://#diff-ff058971f2965e06294c1804d9493bb6d649ffb423b84659949c4ae15b53f7ceR124)
  - Updated `sora_api.go` to include `TotalIhaveOverflow` in the `soraClusterRelayPlumtree` struct for API compatibility.

### Testing updates:

* **Test data and metrics validation:**
  - Added test data for `total_ihave_overflow` in `main_test.go` to validate the new metric's behavior. [[1]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR47) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR69)
  - Updated `test/maximum.metrics` and `test/sora_cluster_metrics_enabled.metrics` with expected outputs for `cluster_relay_plumtree_ihave_overflow_total`. [[1]](diffhunk://#diff-f59a1e8fe7c71e1ed2ee047db128668aa25be5c668813fa60c05326bbe1ed008R89-R92) [[2]](diffhunk://#diff-af71e290dc9fe303ae574f91e3e07f39b9690d5c76019835d3ecc6fc43a91afaR89-R92)